### PR TITLE
Reuse server renderer state on the client side

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -3,7 +3,7 @@
 Last but not least this chapter ships the API reference in detail. Despite explaining every single method its arguments and return value, you will also find some tips on some pages.
 
 ## Top-Level API
-* [`createRenderer([config])`](api/createRenderer.md)
+* [`createRenderer([config, initialState])`](api/createRenderer.md)
 * [`render(renderer, mountNode)`](api/render.md)
 * [`combineRules(...rules)`](api/combineRules.md)
 * [`enhance(...enhancers)`](api/enhance.md)

--- a/docs/api/Renderer.md
+++ b/docs/api/Renderer.md
@@ -14,6 +14,7 @@ You should only have a single renderer which handles all styles of your whole ap
 * [`renderToString()`](#rendertostring)
 * [`subscribe(listener)`](#subscribelistener)
 * [`clear()`](#clear)
+* [`getState()`](#getState)
 
 ## `renderRule(rule, [props])`
 Renders a `rule` using the `props` to resolve it.
@@ -214,3 +215,6 @@ subscription.unsubscribe()
 
 ## `clear()`
 Clears the whole cache.
+
+## `getState()`
+Returns the current state of the renderer. Needed to reuse the renderer state from the server on the client side.

--- a/docs/api/createRenderer.md
+++ b/docs/api/createRenderer.md
@@ -5,6 +5,7 @@ It caches all rendered styles to be able to reuse them on future rendering cycle
 
 ## Arguments
 1. `config`(*Object?*): Optional renderer configuration. The most common use case adding [plugins](../advanced/Plugins.md) to process styles before they get cached. *(See [renderer configuration](Renderer.md#configuration) for further information)*.
+2. `initialState`: Optional initial renderer state. Used for reuse a server-generated style-state. *(See [renderer getState()](Renderer.md#getState) for getting this state)*
 
 ## Returns
 ([Renderer](Renderer.md)): A Renderer instance.

--- a/modules/createRenderer.js
+++ b/modules/createRenderer.js
@@ -5,8 +5,10 @@ import getFontFormat from './utils/getFontFormat'
 import cssifyKeyframe from './utils/cssifyKeyframe'
 import cssifyObject from './utils/cssifyObject'
 
-export default function createRenderer(config = { }) {
+export default function createRenderer(config = { }, initialState = { }) {
   const renderer = {
+    emitCounter: 0,
+    emitOffset: typeof initialState.emitCounter === 'number' ? parseInt(initialState.emitCounter) : 0,
     listeners: [],
     keyframePrefixes: config.keyframePrefixes || [ '-webkit-', '-moz-' ],
     plugins: config.plugins || [ ],
@@ -186,13 +188,31 @@ export default function createRenderer(config = { }) {
     },
 
     /**
+     * Returns the current state of the renderer
+     * Can be used to transport the renderer state from server to client
+     *
+     * @return {Object} Containing the renderer state
+     */
+    getState() {
+      return {
+        emitCounter: renderer.emitCounter
+      }
+    },
+
+    /**
      * calls each listener with the current CSS markup of all caches
      * gets only called if the markup actually changes
+     * gets aborted when styles are already rendered on the server
      *
      * @param {Function} callback - callback function which will be executed
      * @return {Object} equivalent unsubscribe method
      */
     _emitChange() {
+      renderer.emitCounter++
+      if(renderer.emitOffset > 0){
+        renderer.emitOffset--
+        return
+      }
       const css = renderer.renderToString()
       renderer.listeners.forEach(listener => listener(css))
     },

--- a/modules/render.js
+++ b/modules/render.js
@@ -22,5 +22,8 @@ export default function render(renderer, mountNode) {
   renderer.subscribe(css => mountNode.textContent = css)
 
   // render currently rendered styles to the DOM once
-  mountNode.textContent = renderer.renderToString()
+  // => Only when they have not been rendered on the server before
+  if (renderer.emitOffset <= 0) {
+    mountNode.textContent = renderer.renderToString()
+  }
 }


### PR DESCRIPTION
Solves #50 

**How it works:**

On the server-side I'm counting all `_emitChange` calls. When I have got the same styles rendered on the server and on the client, the number of `_emitChange` calls is the same. So after passing the state to the client-side renderer it ignores the first `n` `_emitChange` calls and does not apply the styles initially to the mount node. 

So the styles do not get unnecessary rerendered in the users browser, which improves the performance and user-experience.

  