### PR TITLE
Support multiple font family declarations

### DIFF
--- a/modules/createRenderer.js
+++ b/modules/createRenderer.js
@@ -141,7 +141,9 @@ export default function createRenderer(config = { }) {
      * @return {string} fontFamily reference
      */
     renderFont(family, files, properties = { }) {
-      if (!renderer.rendered.hasOwnProperty(family)) {
+      const key = family + generatePropsReference(properties)
+      
+      if (!renderer.rendered.hasOwnProperty(key)) {
         const fontFace = {
           fontFamily: '\'' + family + '\'',
           src: files.map(src => 'url(\'' + src + '\') format(\'' + getFontFormat(src) + '\')').join(',')
@@ -151,7 +153,7 @@ export default function createRenderer(config = { }) {
         Object.keys(properties).filter(prop => fontProperties.indexOf(prop) > -1).forEach(fontProp => fontFace[fontProp] = properties[fontProp])
 
         const css = '@font-face{' + cssifyObject(fontFace) + '}'
-        renderer.rendered[family] = true
+        renderer.rendered[key] = true
         renderer.fontFaces += css
         renderer._emitChange()
       }

--- a/test/createRenderer-test.js
+++ b/test/createRenderer-test.js
@@ -1,4 +1,5 @@
 import createRenderer from '../modules/createRenderer'
+import generatePropsReference from '../modules/utils/generatePropsReference'
 
 describe('Renderer', () => {
   describe('Instantiating a new Renderer', () => {
@@ -285,12 +286,18 @@ describe('Renderer', () => {
   describe('Rendering Fonts', () => {
     it('should cache the font-face', () => {
       const renderer = createRenderer()
-
-      const family = renderer.renderFont('Arial', [ '../fonts/Arial.ttf', '../fonts/Arial.woff' ], {
+      const family = 'Arial'
+      const properties = {
         fontWeight: 300
-      })
+      }
 
-      expect(renderer.rendered.hasOwnProperty(family)).to.eql(true)
+      renderer.renderFont(family, [
+        '../fonts/Arial.ttf',
+        '../fonts/Arial.woff'
+      ], properties)
+
+      const key = family + generatePropsReference(properties)
+      expect(renderer.rendered.hasOwnProperty(key)).to.eql(true)
     })
 
     it('should return the font family', () => {


### PR DESCRIPTION
Most often font weights and styles are split into different files and require seperate @font-face imports.
```js
renderer.renderFont('Avinor', [
  require('./assets/fonts/avinor-bold.woff'),
  require('./assets/fonts/avinor-bold.woff2'),
], {
  fontWeight: '700',
})
renderer.renderFont('Avinor', [
  require('./assets/fonts/avinor-medium.woff'),
  require('./assets/fonts/avinor-medium.woff2'),
], {
  fontWeight: '400',
})
renderer.renderFont('Avinor', [
  require('./assets/fonts/avinor-light.woff'),
  require('./assets/fonts/avinor-light.woff2'),
], {
  fontWeight: '300',
})
```
As of now this is not supported in Fela since only the first declaration with the family name will be rendered.

This PR suggests using the same technique as in `renderRule` where instead of using the family name as the key, we store the declaration with the name  and a hash of its properties.