### PR TITLE
[react-fela] Rule name as displayName

### DIFF
--- a/modules/bindings/react/connect.js
+++ b/modules/bindings/react/connect.js
@@ -13,7 +13,7 @@ export default function connect(mapStylesToProps) {
     render() {
       // invoke the component name for better CSS debugging
       if (process.env.NODE_ENV !== 'production') {
-        this.context.renderer._selectorPrefix = (Comp.displayName || Comp.name || 'ConnectedFelaComponent') + '__'
+        this.context.renderer._selectorPrefix = Comp.displayName || Comp.name || 'ConnectedFelaComponent'
       }
 
       // invoke props and renderer to render all styles

--- a/modules/bindings/react/createComponent.js
+++ b/modules/bindings/react/createComponent.js
@@ -22,5 +22,9 @@ export default function createComponent(rule, type = 'div', passThroughProps = {
   }
 
   component.contextTypes = { renderer: PropTypes.object }
+
+  // use the rule name as display name to better debug with react inspector ( see #99 )
+  component.displayName = rule.name && rule.name || 'FelaComponent'
+
   return component
 }

--- a/modules/bindings/react/createComponent.js
+++ b/modules/bindings/react/createComponent.js
@@ -1,7 +1,7 @@
 import { createElement, PropTypes } from 'react'
 
 export default function createComponent(rule, type = 'div', passThroughProps = {}) {
-  const component = ({ children, className, style, id, ...felaProps }, { renderer }) => {
+  const component = ({ children, className, style, ...felaProps }, { renderer }) => {
 
     // filter props to extract props to pass through
     const componentProps = Object.keys(passThroughProps).reduce((output, prop) => {
@@ -12,7 +12,6 @@ export default function createComponent(rule, type = 'div', passThroughProps = {
       return output
     }, { })
 
-    componentProps.id = id
     componentProps.style = style
 
     const cls = className ? className + ' ' : ''

--- a/modules/createRenderer.js
+++ b/modules/createRenderer.js
@@ -98,12 +98,12 @@ export default function createRenderer(config = { }) {
         }
 
         // keep static style to diff dynamic onces later on
-        if (className === classNamePrefix + ruleId) {
+        if (className === renderer._classNamePrefix + ruleId) {
           renderer.base[ruleId] = diffedStyle
         }
       }
 
-      const baseClassName = classNamePrefix + ruleId
+      const baseClassName = renderer._classNamePrefix + ruleId
       // if current className is empty
       // return either the static class or empty string
       if (!renderer.rendered[className]) {

--- a/modules/createRenderer.js
+++ b/modules/createRenderer.js
@@ -24,7 +24,6 @@ export default function createRenderer(config = { }) {
     // try and use readable selectors when
     // prettySelectors is on and not in a prod environment
     prettySelectors: config.prettySelectors && process.env.NODE_ENV !== 'production',
-    _classNamePrefix: '',
 
     /**
      * clears the sheet's cache but keeps all listeners
@@ -68,13 +67,14 @@ export default function createRenderer(config = { }) {
       const ruleId = renderer.ids.indexOf(rule)
 
 
+      let classNamePrefix = 'c'
       // extend the className with prefixes in development
       // this enables better debugging and className readability
       if (process.env.NODE_ENV !== 'production') {
-        renderer._classNamePrefix = (renderer._selectorPrefix + '__' || '') + renderer.prettySelectors && rule.name ? rule.name + '__' : ''
+        classNamePrefix = (renderer._selectorPrefix ? (renderer._selectorPrefix + '__') : '') + ((renderer.prettySelectors && rule.name) ? rule.name + '__' : '') + 'c'
       }
 
-      const className = renderer._classNamePrefix + 'c' + ruleId + generatePropsReference(props)
+      const className = classNamePrefix + ruleId + generatePropsReference(props)
 
       // only if the cached rule has not already been rendered
       // with a specific set of properties it actually renders
@@ -98,12 +98,12 @@ export default function createRenderer(config = { }) {
         }
 
         // keep static style to diff dynamic onces later on
-        if (className === renderer._classNamePrefix + ruleId) {
+        if (className === classNamePrefix + ruleId) {
           renderer.base[ruleId] = diffedStyle
         }
       }
 
-      const baseClassName = renderer._classNamePrefix + ruleId
+      const baseClassName = classNamePrefix + ruleId
       // if current className is empty
       // return either the static class or empty string
       if (!renderer.rendered[className]) {

--- a/modules/createRenderer.js
+++ b/modules/createRenderer.js
@@ -24,6 +24,7 @@ export default function createRenderer(config = { }) {
     // try and use readable selectors when
     // prettySelectors is on and not in a prod environment
     prettySelectors: config.prettySelectors && process.env.NODE_ENV !== 'production',
+    _classNamePrefix: '',
 
     /**
      * clears the sheet's cache but keeps all listeners
@@ -66,8 +67,14 @@ export default function createRenderer(config = { }) {
       // uses the reference ID and the props to generate an unique className
       const ruleId = renderer.ids.indexOf(rule)
 
-      const classNamePrefix = renderer.prettySelectors && rule.name ? rule.name + '__' : 'c'
-      const className = (renderer._selectorPrefix || '') + classNamePrefix + ruleId + generatePropsReference(props)
+
+      // extend the className with prefixes in development
+      // this enables better debugging and className readability
+      if (process.env.NODE_ENV !== 'production') {
+        renderer._classNamePrefix = (renderer._selectorPrefix + '__' || '') + renderer.prettySelectors && rule.name ? rule.name + '__' : ''
+      }
+
+      const className = renderer._classNamePrefix + 'c' + ruleId + generatePropsReference(props)
 
       // only if the cached rule has not already been rendered
       // with a specific set of properties it actually renders

--- a/test/bindings/react/createComponent-test.js
+++ b/test/bindings/react/createComponent-test.js
@@ -57,10 +57,6 @@ describe('Creating Components from Fela rules', () => {
     const Button = props => ({ color: 'red', fontSize: 16 })
     const component = createComponent(Button)
 
-    const renderer = createRenderer()
-
-    const element = component({ }, { renderer })
-    console.log(element)
-    expect(element.displayName).to.eql('Button')
+    expect(component.displayName).to.eql('Button')
   })
 })

--- a/test/bindings/react/createComponent-test.js
+++ b/test/bindings/react/createComponent-test.js
@@ -1,5 +1,5 @@
-import createComponent from '../../modules/bindings/react/createComponent'
-import createRenderer from '../../modules/createRenderer'
+import createComponent from '../../../modules/bindings/react/createComponent'
+import createRenderer from '../../../modules/createRenderer'
 
 describe('Creating Components from Fela rules', () => {
   it('should return a Component', () => {
@@ -51,5 +51,16 @@ describe('Creating Components from Fela rules', () => {
 
     expect(element.props.foo).to.eql(true)
     expect(renderer.rules).to.eql('.c0{color:red;font-size:16}.c0--1u3zxk{color:black}')
+  })
+
+  it('should only use the rule name as displayName', () => {
+    const Button = props => ({ color: 'red', fontSize: 16 })
+    const component = createComponent(Button)
+
+    const renderer = createRenderer()
+
+    const element = component({ }, { renderer })
+    console.log(element)
+    expect(element.displayName).to.eql('Button')
   })
 })

--- a/test/createRenderer-test.js
+++ b/test/createRenderer-test.js
@@ -246,7 +246,7 @@ describe('Renderer', () => {
 
       const className = renderer.renderRule(nicelyNamedRule)
 
-      expect(className).to.eql('nicelyNamedRule__0')
+      expect(className).to.eql('nicelyNamedRule__c0')
     })
 
     it('should name classes correctly when the rule name cannot be inferred', () => {
@@ -271,7 +271,7 @@ describe('Renderer', () => {
 
       const className = renderer.renderRule(rule)
 
-      expect(className).to.eql('combined__0')
+      expect(className).to.eql('combined__c0')
     })
 
     it('should not name classes after their rule when prettySelectors is false', () => {

--- a/test/createRenderer-test.js
+++ b/test/createRenderer-test.js
@@ -246,7 +246,7 @@ describe('Renderer', () => {
 
       const className = renderer.renderRule(nicelyNamedRule)
 
-      expect(className).to.eql('nicelyNamedRule_0')
+      expect(className).to.eql('nicelyNamedRule__0')
     })
 
     it('should name classes correctly when the rule name cannot be inferred', () => {
@@ -257,18 +257,6 @@ describe('Renderer', () => {
       const className = renderer.renderRule(() => ({ color: 'red' }))
 
       expect(className).to.eql('c0')
-    })
-
-    it('should name classes correctly when a classPrefix is passed via props', () => {
-      const renderer = createRenderer({ prettySelectors: true })
-
-      process.env.NODE_ENV = 'development'
-
-      const text = props => ({ color: 'red' })
-
-      const className = renderer.renderRule(text, { }, 'Header_')
-
-      expect(className).to.eql('Header_text_0')
     })
 
     it('should name classes correctly when rules are combined', () => {
@@ -283,7 +271,7 @@ describe('Renderer', () => {
 
       const className = renderer.renderRule(rule)
 
-      expect(className).to.eql('combined_0')
+      expect(className).to.eql('combined__0')
     })
 
     it('should not name classes after their rule when prettySelectors is false', () => {


### PR DESCRIPTION
As proposed by @maxharris9 (https://github.com/rofrischmann/fela/issues/99)

We are now able to use the rule name as displayName. This is quite powerful used together with `prettySelectors`.

e.g 
```javascript
import { createComponent } from 'fela'

const Button = props => ({
  // styles
})

export default createComponent(Button)
```

```
import Button from './Button'

ReactDOM.render(<Button />, document.body)
```

will be displayed (React Inspector):
```HTML
<Button class='Button__c0'></Button>
```