### PR TITLE
Pretty props reference

### DIFF
--- a/modules/createRenderer.js
+++ b/modules/createRenderer.js
@@ -68,13 +68,18 @@ export default function createRenderer(config = { }) {
 
 
       let classNamePrefix = 'c'
+      let propsReference = generatePropsReference(props)
+
       // extend the className with prefixes in development
       // this enables better debugging and className readability
       if (process.env.NODE_ENV !== 'production') {
         classNamePrefix = (renderer._selectorPrefix ? (renderer._selectorPrefix + '__') : '') + ((renderer.prettySelectors && rule.name) ? rule.name + '__' : '') + 'c'
+        // replace the cryptic hash reference with a concatenated and simplyfied version of the props object itself
+        propsReference = renderer.prettySelectors ? ((Object.keys(props).length > 0 ? '--' : '') + Object.keys(props).sort().map(prop => prop + '-' + props[prop]).join('---').replace(/ /g, '_').match(/[-_a-zA-Z0-9]*/g).join('')) : propsReference
       }
 
-      const className = classNamePrefix + ruleId + generatePropsReference(props)
+
+      const className = classNamePrefix + ruleId + propsReference
 
       // only if the cached rule has not already been rendered
       // with a specific set of properties it actually renders

--- a/modules/createRenderer.js
+++ b/modules/createRenderer.js
@@ -75,7 +75,9 @@ export default function createRenderer(config = { }) {
       if (process.env.NODE_ENV !== 'production') {
         classNamePrefix = (renderer._selectorPrefix ? (renderer._selectorPrefix + '__') : '') + ((renderer.prettySelectors && rule.name) ? rule.name + '__' : '') + 'c'
         // replace the cryptic hash reference with a concatenated and simplyfied version of the props object itself
-        propsReference = renderer.prettySelectors ? ((Object.keys(props).length > 0 ? '--' : '') + Object.keys(props).sort().map(prop => prop + '-' + props[prop]).join('---').replace(/ /g, '_').match(/[-_a-zA-Z0-9]*/g).join('')) : propsReference
+        if (renderer.prettySelectors && Object.keys(props).length > 0) {
+          propsReference += '__' + Object.keys(props).sort().map(prop => prop + '-' + props[prop]).join('---').replace(/ /g, '_').match(/[-_a-zA-Z0-9]*/g).join('')
+        }
       }
 
 

--- a/test/createRenderer-test.js
+++ b/test/createRenderer-test.js
@@ -264,7 +264,7 @@ describe('Renderer', () => {
         fontSize: 15
       })
 
-      expect(className).to.eql('nicelyNamedRule__c0--color-ffffff---fontSize-15')
+      expect(className).to.eql('nicelyNamedRule__c0--bd3amk__color-ffffff---fontSize-15')
     })
 
     it('should name classes correctly when the rule name cannot be inferred', () => {

--- a/test/createRenderer-test.js
+++ b/test/createRenderer-test.js
@@ -249,6 +249,24 @@ describe('Renderer', () => {
       expect(className).to.eql('nicelyNamedRule__c0')
     })
 
+    it('should produce readable props references', () => {
+      const nicelyNamedRule = props => ({
+        color: props.color,
+        fontSize: props.fontSize
+      })
+
+      process.env.NODE_ENV = 'development'
+
+      const renderer = createRenderer({ prettySelectors: true })
+
+      const className = renderer.renderRule(nicelyNamedRule, {
+        color: '#ffffff',
+        fontSize: 15
+      })
+
+      expect(className).to.eql('nicelyNamedRule__c0--color-ffffff---fontSize-15')
+    })
+
     it('should name classes correctly when the rule name cannot be inferred', () => {
       const renderer = createRenderer({ prettySelectors: true })
 


### PR DESCRIPTION
Enables #98 

e.g.
```javascript
const Button = props => ({ color: props.color, fontSize: props.fontSize })

const cls = renderer.renderRule(Button, { color: '#ffffff', fontSize: 15 })

console.log(cls)
// => Button__c0--bd3amk__color-ffffff---fontSize-15
```