### PR TITLE
Switch from hashing input props to rule output

### DIFF
--- a/modules/createRenderer.js
+++ b/modules/createRenderer.js
@@ -157,7 +157,7 @@ export default function createRenderer(config = { }) {
         renderer.ids.push(keyframe)
       }
 
-      const styleOutput = keyframe(props);
+      const styleOutput = keyframe(props)
       const propsReference = Object.keys(props).length > 0
         ? generatePropsReference(styleOutput)
         : ''

--- a/modules/createRenderer.js
+++ b/modules/createRenderer.js
@@ -71,10 +71,12 @@ export default function createRenderer(config = { }) {
 
       // uses the reference ID and the props to generate an unique className
       const ruleId = renderer.ids.indexOf(rule)
-
+      const styleOutput = rule(props)
 
       let classNamePrefix = 'c'
-      let propsReference = generatePropsReference(props)
+      let propsReference = Object.keys(props).length > 0
+        ? generatePropsReference(styleOutput)
+        : ''
 
       // extend the className with prefixes in development
       // this enables better debugging and className readability
@@ -100,7 +102,7 @@ export default function createRenderer(config = { }) {
       // with a specific set of properties it actually renders
       if (!renderer.rendered.hasOwnProperty(className)) {
         // process style using each plugin
-        const style = processStyle(rule(props), {
+        const style = processStyle(styleOutput, {
           type: 'rule',
           className: className,
           id: ruleId,
@@ -155,14 +157,18 @@ export default function createRenderer(config = { }) {
         renderer.ids.push(keyframe)
       }
 
-      const propsReference = generatePropsReference(props)
+      const styleOutput = keyframe(props);
+      const propsReference = Object.keys(props).length > 0
+        ? generatePropsReference(styleOutput)
+        : ''
+
       const prefix = renderer.prettySelectors && keyframe.name ? keyframe.name + '_' : 'k'
       const animationName = prefix + renderer.ids.indexOf(keyframe) + propsReference
 
       // only if the cached keyframe has not already been rendered
       // with a specific set of properties it actually renders
       if (!renderer.rendered.hasOwnProperty(animationName)) {
-        const processedKeyframe = processStyle(keyframe(props), {
+        const processedKeyframe = processStyle(styleOutput, {
           type: 'keyframe',
           keyframe: keyframe,
           props: props,

--- a/modules/native/createRenderer.js
+++ b/modules/native/createRenderer.js
@@ -32,12 +32,17 @@ export default function createRenderer(config = { }) {
 
       // uses the reference ID and the props to generate an unique className
       const ruleId = renderer.ids.indexOf(rule)
-      const ref = ruleId + generatePropsReference(props)
+      const styleOutput = renderer._resolveStyle(rule, props)
+      const propsReference = Object.keys(props).length > 0
+        ? generatePropsReference(styleOutput)
+        : ''
+
+      const ref = ruleId + propsReference
 
       // only if the cached rule has not already been rendered
       // with a specific set of properties it actually renders
       if (!renderer.rules.hasOwnProperty(ref)) {
-        const style = processStyle(renderer._resolveStyle(rule, props), {
+        const style = processStyle(styleOutput, {
           type: 'rule',
           id: ruleId,
           props: props,

--- a/modules/utils/generatePropsReference.js
+++ b/modules/utils/generatePropsReference.js
@@ -1,6 +1,5 @@
 /* @flow weak */
 import generateContentHash from './generateContentHash'
-import sortedStringify from './sortedStringify'
 
 /**
  * generates an unique reference id by content hashing props
@@ -8,4 +7,4 @@ import sortedStringify from './sortedStringify'
  * @param {Object} props - props that get hashed
  * @return {string} reference - unique props reference
  */
-export default props => generateContentHash(sortedStringify(props))
+export default props => generateContentHash(JSON.stringify(props))

--- a/test/bindings/react/createComponent-test.js
+++ b/test/bindings/react/createComponent-test.js
@@ -18,8 +18,8 @@ describe('Creating Components from Fela rules', () => {
     const element = component({ color: 'black' }, { renderer })
 
     expect(element.type).to.eql('div')
-    expect(element.props.className).to.eql('c0 c0-ldchvg')
-    expect(renderer.rules).to.eql('.c0{font-size:16}.c0-ldchvg{color:black}')
+    expect(element.props.className).to.eql('c0 c0--j3ki0n')
+    expect(renderer.rules).to.eql('.c0{font-size:16}.c0--j3ki0n{color:black}')
   })
 
   it('should only pass explicit props to the element', () => {
@@ -50,7 +50,7 @@ describe('Creating Components from Fela rules', () => {
     })
 
     expect(element.props.foo).to.eql(true)
-    expect(renderer.rules).to.eql('.c0{color:red;font-size:16}.c0--1u3zxk{color:black}')
+    expect(renderer.rules).to.eql('.c0{color:red;font-size:16}.c0--j3ki0n{color:black}')
   })
 
   it('should only use the rule name as displayName', () => {

--- a/test/createRenderer-test.js
+++ b/test/createRenderer-test.js
@@ -118,7 +118,7 @@ describe('Renderer', () => {
       expect(className).to.eql(className2)
       expect(className).to.eql(className3)
       expect(renderer.rules).to.eql('.c0{font-size:23px}')
-      expect(Object.keys(renderer.rendered).length).to.eql(3)
+      expect(Object.keys(renderer.rendered).length).to.eql(2)
     })
 
     it('should return an empty string if the style is empty', () => {
@@ -127,7 +127,7 @@ describe('Renderer', () => {
 
       const className = renderer.renderRule(rule, { color: 'red' })
 
-      expect(className).to.eql('c0--aedinm')
+      expect(className).to.eql('c0--wrg8o2')
     })
 
     it('should only return a dynamic className', () => {
@@ -275,7 +275,7 @@ describe('Renderer', () => {
         fontSize: 15
       })
 
-      expect(className).to.eql('nicelyNamedRule__c0--bd3amk__color-ffffff---fontSize-15')
+      expect(className).to.eql('nicelyNamedRule__c0-udqq8e__color-ffffff---fontSize-15')
     })
 
     it('should name classes correctly when the rule name cannot be inferred', () => {
@@ -378,8 +378,8 @@ describe('Renderer', () => {
         color: 'red'
       })
 
-      expect(animationName).to.eql('k0--aedinm')
-      expect(renderer.keyframes).to.eql('@-webkit-keyframes k0--aedinm{from{color:red}to{color:blue}}@-moz-keyframes k0--aedinm{from{color:red}to{color:blue}}@keyframes k0--aedinm{from{color:red}to{color:blue}}')
+      expect(animationName).to.eql('k0-exrjx8')
+      expect(renderer.keyframes).to.eql('@-webkit-keyframes k0-exrjx8{from{color:red}to{color:blue}}@-moz-keyframes k0-exrjx8{from{color:red}to{color:blue}}@keyframes k0-exrjx8{from{color:red}to{color:blue}}')
     })
   })
 

--- a/test/utils/generatePropsReference-test.js
+++ b/test/utils/generatePropsReference-test.js
@@ -6,16 +6,4 @@ describe('Generating the props reference', () => {
     const className2 = generatePropsReference('foobar')
     expect(className1).to.eql(className2)
   })
-
-  it('should sort props before', () => {
-    const className1 = generatePropsReference({
-      foo: 'bar',
-      fontSize: 12
-    })
-    const className2 = generatePropsReference({
-      fontSize: 12,
-      foo: 'bar'
-    })
-    expect(className1).to.eql(className2)
-  })
 })


### PR DESCRIPTION
Instead of hashing the input props we should hash the result of `rule(props)`;
This allows support for deeply nested properties and is actually faster overall in comparing changes.
Sorting the object was the slowest part of the process. I've replaced stringifySort with JSON.stringify since the order of the style object's properties shouldn't change order.