### PR TITLE
Fix incorrect font format

### DIFF
--- a/modules/utils/getFontFormat.js
+++ b/modules/utils/getFontFormat.js
@@ -1,7 +1,7 @@
 /* @flow weak */
 const formats = {
   '.woff': 'woff',
-  '.eof': 'eof',
+  '.eot': 'eot',
   '.ttf': 'truetype',
   '.svg': 'svg'
 }


### PR DESCRIPTION
It's `.eot`, not `.eof`.

ping @rofrischmann  :D