### PR TITLE
Add community links

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ The following list shows a quick overview of all existing packages.
 Join us on [Gitter](https://gitter.im/rofrischmann/fela). We highly appreciate any contribution.<br>
 We also love to get feedback.
 
+## Community
+* [Aesthetic](https://github.com/milesj/aesthetic) - A React style and theme layer with Fela support.
 
 ## License
 Fela is licensed under the [MIT License](http://opensource.org/licenses/MIT).<br>


### PR DESCRIPTION
I've been working on a React style abstraction layer these past few weeks and have integrated Fela support today (amazing work on this library, one of my favorites). Thought it nice to include some links to community libraries that make use of Fela.

* https://github.com/milesj/aesthetic
* https://github.com/milesj/aesthetic/tree/master/packages/aesthetic-fela