### PR TITLE
feat(react-fela): Use `Themed<displayName>` for connected components

### DIFF
--- a/modules/bindings/react/connect.js
+++ b/modules/bindings/react/connect.js
@@ -3,13 +3,13 @@
 import React, { Component, PropTypes } from 'react'
 
 const generateDisplayName = (Comp) => {
-  const displayName = Comp.displayName || Comp.name;
+  const displayName = Comp.displayName || Comp.name
   if (displayName) {
-    return `Themed${displayName}`;
+    return `Themed${displayName}`
   }
-  
-  return 'ConnectedFelaComponent';
-};
+
+  return 'ConnectedFelaComponent'
+}
 
 export default function connect(mapStylesToProps) {
   return Comp => class EnhancedComponent extends Component {

--- a/modules/bindings/react/connect.js
+++ b/modules/bindings/react/connect.js
@@ -2,10 +2,19 @@
 /* eslint-disable react/prefer-stateless-function */
 import React, { Component, PropTypes } from 'react'
 
+const generateDisplayName = Comp => {
+  const displayName = Comp.displayName || Comp.name;
+  if (displayName) {
+    return `Themed${displayName}`;
+  }
+  
+  return 'ConnectedFelaComponent';
+}
+
 export default function connect(mapStylesToProps) {
   return Comp => class EnhancedComponent extends Component {
     // reuse the initial displayName name
-    static displayName = Comp.displayName || Comp.name || 'ConnectedFelaComponent';
+    static displayName = generateDisplayName(Comp);
 
     static contextTypes = {
       ...Comp.contextTypes,

--- a/modules/bindings/react/connect.js
+++ b/modules/bindings/react/connect.js
@@ -2,14 +2,14 @@
 /* eslint-disable react/prefer-stateless-function */
 import React, { Component, PropTypes } from 'react'
 
-const generateDisplayName = Comp => {
+const generateDisplayName = (Comp) => {
   const displayName = Comp.displayName || Comp.name;
   if (displayName) {
     return `Themed${displayName}`;
   }
   
   return 'ConnectedFelaComponent';
-}
+};
 
 export default function connect(mapStylesToProps) {
   return Comp => class EnhancedComponent extends Component {

--- a/modules/bindings/react/connect.js
+++ b/modules/bindings/react/connect.js
@@ -5,7 +5,7 @@ import React, { Component, PropTypes } from 'react'
 const generateDisplayName = (Comp) => {
   const displayName = Comp.displayName || Comp.name
   if (displayName) {
-    return `Themed${displayName}`
+    return `Fela${displayName}`
   }
 
   return 'ConnectedFelaComponent'


### PR DESCRIPTION
Currently, any `HoC`'d component that is wrapped using `connect` gains the same `displayName` (or similar) as it's own. This can be a little confusing when viewing the React DOM using the Developer Tools:

![React DevTools](https://i.imgur.com/xwUN3FG.png)

This feature simply preprends the name with ` Themed` prefix for easier visual distinctions.