### PR TITLE
Union class names feature

### DIFF
--- a/test/createRenderer-test.js
+++ b/test/createRenderer-test.js
@@ -71,7 +71,6 @@ describe('Renderer', () => {
       expect(renderer.cache.hasOwnProperty('color' + 'red')).to.eql(true)
     })
 
-
     it('should reuse cached classNames', () => {
       const rule = props => ({ color: props.color, fontSize: '23px' })
       const renderer = createRenderer()
@@ -217,6 +216,18 @@ describe('Renderer', () => {
 
       expect(renderer.rules).to.eql('.a{color:red}')
       expect(renderer.mediaRules['(min-height:300px)']).to.eql('.b{color:blue}')
+    })
+
+    it('should redner union classNames', () => {
+      const rule = props => ({ color: props.color, fontSize: '23px' })
+      const renderer = createRenderer()
+
+      const className1 = renderer.renderUnionRule(rule, { color: 'red' })
+      const className2 = renderer.renderUnionRule(rule, { color: 'red' })
+
+      expect(className1).to.eql(className2)
+      expect(className1).to.eql('a')
+      expect(renderer.rules).to.eql('.a{color:red;font-size:23px}')
     })
   })
 


### PR DESCRIPTION
NOTE: This is just idea. I don't think this code is OK for merging but I just want to discuss this feature.

*"Talk is cheap. Show me the code" Torvalds, Linus*  :)

-----
For some reasons I want to generate union classes:

Now:
```js
const className1 = renderer.renderRule(rule, { color: 'red' })
const className2 = renderer.renderRule(rule, { color: 'red' })

expect(className1).to.eql(className2)
expect(className1).to.eql('a b')

expect(renderer.rules).to.eql('.a{color:red}.b{font-size:23px}')
```

I want:

```js
const className1 = renderer.renderUnionRule(rule, { color: 'red' })
const className2 = renderer.renderUnionRule(rule, { color: 'red' })

 expect(className1).to.eql(className2)
 expect(className1).to.eql('a')

 expect(renderer.rules).to.eql('.a{color:red;font-size:23px}')
```

For example - use default approach (atom) for prod env and union for dev. It is much easier to develop and test when there are few classes. Instead of this:

![image](https://cloud.githubusercontent.com/assets/5140611/23027716/d5b825c0-f46d-11e6-90e9-65e5d60ab6f0.png)
