### PR TITLE
Custom classnames for Monolithic

### DIFF
--- a/docs/advanced/DeveloperExperience.md
+++ b/docs/advanced/DeveloperExperience.md
@@ -34,7 +34,7 @@ const App = (
 
 ## Monolithic class names
 Using atomic class names design for developing can be quite hard to debug so we support monolithic class names.
-Atomic class names will give you `n` number of classes when you `renderer.renderRule` while monolithic design will give you one class name with all the rules.
+Atomic class names will give you `n` number of classes when you `renderer.renderRule` while monolithic design will give you one class name with all the rules. By default, the class names are based on properties (it's a simple hash function). If you want to fix the class name, you can add property `className` into your rule set. This can be useful if you want to generate an external stylesheet that's human readable, deterministic and can be used on non-JS projects.
 
 Simply include the [Fela Monolithic Enhancer](https://github.com/rofrischmann/fela/tree/master/packages/fela-monolithic).
 

--- a/modules/enhancers/monolithic.js
+++ b/modules/enhancers/monolithic.js
@@ -15,11 +15,17 @@ import normalizeNestedProperty from '../utils/normalizeNestedProperty'
 import { RULE_TYPE } from '../utils/styleTypes'
 
 function generateClassName(str, prefix) {
+  if (str.className) {
+    const name = prefix + str.className
+    delete str.className
+    return name
+  }
+  const stringified = JSON.stringify(str)
   let val = 5381
-  let i = str.length
+  let i = stringified.length
 
   while (i) {
-    val = val * 33 ^ str.charCodeAt((--i))
+    val = val * 33 ^ stringified.charCodeAt((--i))
   }
 
   return prefix + (val >>> 0).toString(36)
@@ -75,7 +81,7 @@ function addMonolithicClassNames(renderer) {
     if (!Object.keys(style).length) {
       return ''
     }
-    const className = generateClassName(JSON.stringify(style), renderer.selectorPrefix || 'fela-')
+    const className = generateClassName(style, renderer.selectorPrefix || 'fela-')
     const selector = generateCSSSelector(className)
 
     if (renderer.cache[className]) return ` ${className}`

--- a/packages/fela-monolithic/README.md
+++ b/packages/fela-monolithic/README.md
@@ -28,7 +28,32 @@ import monolithic from 'fela-monolithic'
 const renderer = createRenderer({
   enhancers: [ monolithic() ]
 })
+
+const rule = () => ({
+  className: 'custom',
+  color: 'red'
+})
+
+renderer.renderRule(rule)
 ```
+
+outputs
+
+```css
+.fela-custom {
+  color: red
+}
+```
+
+if `className` property is not used, the output will be
+
+```css
+.fela-137u7ef {
+  color: red
+}
+```
+
+`137u7ef` is a hash based on rule properties (`color: red` in this case). The prefix `fela` can be configured in createRenderer.
 
 ## License
 Fela is licensed under the [MIT License](http://opensource.org/licenses/MIT).<br>

--- a/packages/fela-monolithic/README.md
+++ b/packages/fela-monolithic/README.md
@@ -5,7 +5,7 @@
 
 The monolithic enhancer will use unique class names instead of atomic ones.
 These generated class names are not re-usable like the atomic design but allows you to debug and modify styles with ease.
-Every ruleset will have it's own unique class - this means that a new class will be generated if you are using props and they change.
+Every ruleset will have it's own unique class - this means that a new class will be generated if you are using props and they change. If you want to fix the class name, you can add property `className` into your rule set. This can be useful if you want to generate an external stylesheet that's human readable, re-usable and can be used on non-JS projects.
 
 ## Installation
 ```sh

--- a/test/enhancers/monolithic.js
+++ b/test/enhancers/monolithic.js
@@ -141,4 +141,16 @@ describe('Monolithic enhancer', () => {
     expect(renderer.rules).to.eql(`.${className}{color:red}`)
     expect(renderer.mediaRules['(min-height:300px)']).to.eql(`.${className}{color:blue}`)
   })
+
+  it('should use custom className if defined', () => {
+    const rule = () => ({
+      className: 'custom',
+      color: 'red'
+    })
+
+    const renderer = createRenderer(options)
+    renderer.renderRule(rule)
+
+    expect(renderer.rules).to.eql('.fela-custom{color:red}')
+  })
 })


### PR DESCRIPTION
Implements https://github.com/rofrischmann/fela/issues/201. 

I might publish the script that will generate the whole BEM like stylesheet using this feature. Not sure if that should be a part of fela since it will be React specific and call the renderer repeatedly. I hope you got the idea. Anyway, that will take longer, since it's not our top priority. We have to transition first. This PR just opens the door. :)