### PR TITLE
Demo JS executes before HTML is parsed

### DIFF
--- a/examples/vanilla/index.html
+++ b/examples/vanilla/index.html
@@ -7,7 +7,6 @@
   <script src="https://unpkg.com/fela@1.1.0/dist/fela.min.js"></script>
   <script src="https://unpkg.com/fela-plugin-prefixer@1.1.0/dist/fela-plugin-prefixer.min.js"></script>
   <script src="https://unpkg.com/fela-plugin-fallback-value@1.1.0/dist/fela-plugin-fallback-value.min.js"></script>
-  <script src="app.js"></script>
   <style id="stylesheet"></style>
   <title>Fela - Examples</title>
 </head>
@@ -18,6 +17,7 @@
       Fela with pure JavaScript and HTML
     </div>
   </div>
+  <script src="app.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
The demo currently throws an error because the script executes before it can get the `#welcome` element. This error might not appear when using a server with a network delay. Every delay causes the script to be executed later => The error doesn't appear.

```
TypeError: null is not an object (evaluating 'document.getElementById('welcome').className = className')
```

I moved the script to the end of the body. The HTML is now parsed and ready when the script executes.