### PR TITLE
Throw an error when createComponent() is used with renderer missing

### DIFF
--- a/modules/bindings/react/createComponent.js
+++ b/modules/bindings/react/createComponent.js
@@ -7,6 +7,13 @@ import combineRules from '../../combineRules'
 
 export default function createComponent(rule, type = 'div', passThroughProps = []) {
   const FelaComponent = ({ children, _felaRule, passThrough = [], ...ruleProps }, { renderer, theme }) => {
+    if (!renderer) {
+      const componentName = type.displayName ? type.displayName : type
+      throw new Error(`
+        createComponent() can't render styles for the component '${componentName}' without
+        Fela renderer in the context. Missing react-fela's <Provider /> at the app root?
+      `)
+    }
     const combinedRule = _felaRule ? combineRules(rule, _felaRule) : rule
 
     // compose passThrough props from arrays or functions


### PR DESCRIPTION
We should give users a nice error if they try to use fela based components (components that are using `createComponent` inside) but the renderer is not present in the context.

**Right now it throws something like this:**

```
 TypeError: Cannot read property 'renderRule' of undefined
```

**New message:**

```
createComponent() can't render styles for the component 'Button' without
Fela renderer in the context. Missing react-fela's <Provider /> at the app root?
```

The fact that a component is using fela can be completely hidden, so this can avoid some confusion.