### PR TITLE
TypeScript fixes

### DIFF
--- a/packages/fela/index.d.ts
+++ b/packages/fela/index.d.ts
@@ -31,6 +31,7 @@ declare module "fela" {
     renderKeyframe(keyFrame: TKeyFrame, props: TRuleProps): string;
     renderFont(family: string, files: Array<string>, props: TRuleProps): void;
     renderStatic(style: string, selector?: string): void;
+    renderStatic(style: IStyle, selector: string): void;
     renderToString(): string;
     subscribe(event: (msg: ISubscribeRuleOrStaticObjectMessage | ISubscribeKeyframesMessage | ISubscribeFontFaceMessage | ISubscribeStaticStringMessage | ISubscribeClearMessage) => void): { unsubscribe: () => void; }
     clear();

--- a/packages/fela/index.d.ts
+++ b/packages/fela/index.d.ts
@@ -1,6 +1,6 @@
 declare module "fela" {
 
-  import React from 'react';
+  import { CSSProperties } from 'react';
 
   type TRuleProps = {};
   type TRule = (props: TRuleProps) => IStyle; 
@@ -45,7 +45,7 @@ declare module "fela" {
     selectorPrefix?: string;
   }
 
-  interface IStyle extends React.CSSProperties {
+  interface IStyle extends CSSProperties {
     //TODO: add properties, missing in React.CSSProperties
   }
 


### PR DESCRIPTION
Fixes the following issues with the TypeScript type def:

* Fixes TypeScript complaining about React not having a default import

* Allows `renderStatic` to be called with a style object instead of a string