### PR TITLE
render children[0] in preact's providers

### DIFF
--- a/modules/bindings/preact/Provider.js
+++ b/modules/bindings/preact/Provider.js
@@ -16,6 +16,6 @@ export default class Provider extends Component {
   }
 
   render({ children }) {
-    return children
+    return children[0]
   }
 }

--- a/modules/bindings/preact/ThemeProvider.js
+++ b/modules/bindings/preact/ThemeProvider.js
@@ -16,7 +16,7 @@ export default class ThemeProvider extends Component {
     }
   }
 
-  render() {
-    return this.props.children
+  render({ children }) {
+    return children[0]
   }
 }


### PR DESCRIPTION
render children[0] in preact's providers because children is always an array in preact 
[https://preactjs.com/guide/differences-to-reac](https://preactjs.com/guide/differences-to-react)