### PR TITLE
Add test for wrong reuse of classnames with monolithic

### DIFF
--- a/modules/enhancers/__tests__/monolithic-test.js
+++ b/modules/enhancers/__tests__/monolithic-test.js
@@ -152,4 +152,20 @@ describe('Monolithic enhancer', () => {
 
     expect(renderer.rules).toEqual('.fela-custom{color:red}')
   })
+
+  it('should create different classNames for different styles', () => {
+    const rule1 = () => ({
+      className: 'custom',
+      color: 'red'
+    })
+    const rule2 = () => ({
+      className: 'custom',
+      color: 'green'
+    })
+    const renderer = createRenderer(options)
+    const className1 = renderer.renderRule(rule1)
+    const className2 = renderer.renderRule(rule2)
+
+    expect(className1).not.toBe(className2)
+  })
 })


### PR DESCRIPTION
This failing test illustrates the issue raised in #240. I'll gladly solve this issue, and submit the corresponding patch if you're interested. If so, do you have any advices? I identified the source of the problem [line 121 of monolithic](https://github.com/rofrischmann/fela/blob/master/modules/enhancers/monolithic.js#L121), where we just check if the className is already used, without checking if the styles correspond.

Naively, I would add a check for the content of the style, and add a hash after the generated name, but I'm not sure it would be the most efficient (especially performance wise). What do you think of that?