### PR TITLE
React 15.5 update: Use prop-types instead React.PropTypes

### DIFF
--- a/modules/bindings/__tests__/createComponentFactory-test.js
+++ b/modules/bindings/__tests__/createComponentFactory-test.js
@@ -1,4 +1,5 @@
-import { createElement, PropTypes } from 'react'
+import { createElement } from 'react'
+import PropTypes from 'prop-types'
 
 import createComponentFactory from '../createComponentFactory'
 import createRenderer from '../../createRenderer'

--- a/modules/bindings/react/Provider.js
+++ b/modules/bindings/react/Provider.js
@@ -1,5 +1,6 @@
 /* @flow */
-import { Component, PropTypes, Children } from 'react'
+import { Component, Children } from 'react'
+import PropTypes from 'prop-types'
 import render from '../../dom/render'
 
 export default class Provider extends Component {

--- a/modules/bindings/react/ThemeProvider.js
+++ b/modules/bindings/react/ThemeProvider.js
@@ -1,5 +1,6 @@
 /* @flow */
-import { Component, PropTypes, Children } from 'react'
+import { Component, Children } from 'react'
+import PropTypes from 'prop-types'
 
 export default class ThemeProvider extends Component {
   static propTypes = {

--- a/modules/bindings/react/connect.js
+++ b/modules/bindings/react/connect.js
@@ -1,5 +1,6 @@
 /* @flow */
-import { Component, createElement, PropTypes } from 'react'
+import { Component, createElement } from 'react'
+import PropTypes from 'prop-types'
 
 import connectFactory from '../connectFactory'
 

--- a/modules/bindings/react/createComponent.js
+++ b/modules/bindings/react/createComponent.js
@@ -1,5 +1,6 @@
 /* @flow */
-import { createElement, PropTypes } from 'react'
+import { createElement } from 'react'
+import PropTypes from 'prop-types'
 
 import createComponentFactory from '../createComponentFactory'
 

--- a/package.json
+++ b/package.json
@@ -61,15 +61,17 @@
     "inferno-create-element": "^1.0.1",
     "inline-style-prefixer": "^3.0.1",
     "jest": "^19.0.2",
+    "preact": "^7.0.0",
     "prettier-eslint": "^4.2.1",
     "prettier-eslint-cli": "^3.1.2",
-    "preact": "^7.0.0",
-    "react": "^15.3.2",
+    "prop-types": "^15.5.8",
+    "react": "^15.5.4",
     "react-native": "^0.42.0",
     "rollup": "0.26.3",
     "rollup-plugin-babel": "2.4.0",
     "rollup-plugin-commonjs": "2.2.1",
     "rollup-plugin-node-resolve": "1.5.0",
     "rollup-plugin-uglify": "0.3.1"
-  }
+  },
+  "dependencies": {}
 }

--- a/packages/react-fela/package.json
+++ b/packages/react-fela/package.json
@@ -24,5 +24,8 @@
   "peerDependencies": {
     "react": "*",
     "fela": "4.3.2"
+  },
+  "dependencies": {
+    "prop-types": "^15.5.8"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2475,15 +2475,16 @@ fbjs-scripts@^0.7.0:
     semver "^5.1.0"
     through2 "^2.0.0"
 
-fbjs@^0.8.4, fbjs@^0.8.5:
-  version "0.8.6"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.6.tgz#7eb67d6986b2d5007a9b6e92e0e7cb6f75cad290"
+fbjs@^0.8.5, fbjs@^0.8.9:
+  version "0.8.12"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
   dependencies:
     core-js "^1.0.0"
     isomorphic-fetch "^2.1.1"
     loose-envify "^1.0.0"
     object-assign "^4.1.0"
     promise "^7.1.1"
+    setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
 figures@^1.3.5:
@@ -4985,6 +4986,12 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
+prop-types@^15.5.7, prop-types@^15.5.8:
+  version "15.5.8"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
+  dependencies:
+    fbjs "^0.8.9"
+
 proto-list@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
@@ -5196,13 +5203,14 @@ react-transform-hmr@^1.0.4:
     global "^4.3.0"
     react-proxy "^1.1.7"
 
-react@^15.3.2:
-  version "15.4.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.4.1.tgz#498e918602677a3983cd0fd206dfe700389a0dd6"
+react@^15.5.4:
+  version "15.5.4"
+  resolved "https://registry.yarnpkg.com/react/-/react-15.5.4.tgz#fa83eb01506ab237cdc1c8c3b1cea8de012bf047"
   dependencies:
-    fbjs "^0.8.4"
+    fbjs "^0.8.9"
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
+    prop-types "^15.5.7"
 
 read-cmd-shim@~1.0.1:
   version "1.0.1"
@@ -5767,6 +5775,10 @@ set-blocking@^2.0.0, set-blocking@~2.0.0:
 set-immediate-shim@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
+
+setimmediate@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
 
 setprototypeof@1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This PR will make react-fela stop throwing warnings with React 15.5 because React.PropTypes is deprecated. `prop-types` should be a dependency of react-fela now.

Non-related question: Do you know https://lernajs.io/? Is there some reason why you don't use it for fela?