### PR TITLE
Embed Fonts/Keyframes in Rules

### DIFF
--- a/modules/createRenderer.js
+++ b/modules/createRenderer.js
@@ -61,7 +61,7 @@ export default function createRenderer(
 
     renderRule(rule: Function, props: Object = {}): string {
       const processedStyle = processStyleWithPlugins(
-        renderer.plugins,
+        renderer,
         rule(props),
         RULE_TYPE
       )
@@ -79,7 +79,7 @@ export default function createRenderer(
         )
 
         const processedKeyframe = processStyleWithPlugins(
-          renderer.plugins,
+          renderer,
           resolvedKeyframe,
           KEYFRAME_TYPE
         )
@@ -117,7 +117,10 @@ export default function createRenderer(
         const fontFace = {
           ...properties,
           src: files
-            .map(src => `url(${checkFontUrl(src)}) format('${checkFontFormat(src)}')`)
+            .map(
+              src =>
+                `url(${checkFontUrl(src)}) format('${checkFontFormat(src)}')`
+            )
             .join(','),
           fontFamily
         }
@@ -140,10 +143,7 @@ export default function createRenderer(
       const staticReference = generateStaticReference(staticStyle, selector)
 
       if (!renderer.cache.hasOwnProperty(staticReference)) {
-        const cssDeclarations = cssifyStaticStyle(
-          staticStyle,
-          renderer.plugins
-        )
+        const cssDeclarations = cssifyStaticStyle(staticStyle, renderer)
         renderer.cache[staticReference] = ''
 
         if (typeof staticStyle === 'string') {
@@ -178,7 +178,7 @@ export default function createRenderer(
       )
     },
 
-    subscribe(callback: Function): {unsubscribe: Function} {
+    subscribe(callback: Function): { unsubscribe: Function } {
       renderer.listeners.push(callback)
 
       return {

--- a/modules/enhancers/statistics.js
+++ b/modules/enhancers/statistics.js
@@ -12,7 +12,7 @@ function lengthInUtf8Bytes(str: string): number {
 }
 
 type RendererWithStatistics = {
-  getStatistics: Function,
+  getStatistics: Function
 };
 
 function addStatistics(

--- a/modules/native/createRenderer.js
+++ b/modules/native/createRenderer.js
@@ -31,7 +31,7 @@ export default function createRenderer(
 
       if (!renderer.cache.hasOwnProperty(reference)) {
         const processedStyle = processStyleWithPlugins(
-          renderer.plugins,
+          renderer,
           style,
           RULE_TYPE
         )

--- a/modules/plugins/embedKeyframeAndFont.js
+++ b/modules/plugins/embedKeyframeAndFont.js
@@ -1,0 +1,33 @@
+/* @flow */
+import isObject from '../utils/isObject'
+
+import type DOMRenderer from '../../flowtypes/DOMRenderer'
+
+type Type = 1 | 2 | 3 | 4 | 5;
+
+function embedKeyframeAndFont(
+  style: Object,
+  type: Type,
+  renderer: DOMRenderer
+): Object {
+  for (const property in style) {
+    const value = style[property]
+
+    if (property === 'fontFace' && isObject(value)) {
+      const { fontFamily, src, ...otherProps } = value
+      if (typeof fontFamily === 'string' && Array.isArray(src)) {
+        style[property] = renderer.renderFont(fontFamily, src, otherProps)
+      } else {
+        // TODO: warning - invalid font data
+      }
+    }
+
+    if (property === 'animationName' && isObject(value)) {
+      style[property] = renderer.renderKeyframe(value)
+    }
+  }
+
+  return style
+}
+
+export default () => embedKeyframeAndFont

--- a/modules/utils/cssifyStaticStyle.js
+++ b/modules/utils/cssifyStaticStyle.js
@@ -6,16 +6,19 @@ import processStyleWithPlugins from './processStyleWithPlugins'
 
 import { STATIC_TYPE } from './styleTypes'
 
+import type NativeRenderer from '../../flowtypes/NativeRenderer'
+import type DOMRenderer from '../../flowtypes/DOMRenderer'
+
 export default function cssifyStaticStyle(
   staticStyle: string | Object,
-  plugins: Array<Function>
+  renderer: DOMRenderer | NativeRenderer
 ): string {
   if (typeof staticStyle === 'string') {
     return minifyCSSString(staticStyle)
   }
 
   const processedStaticStyle = processStyleWithPlugins(
-    plugins,
+    renderer.plugins,
     staticStyle,
     STATIC_TYPE
   )

--- a/modules/utils/processStyleWithPlugins.js
+++ b/modules/utils/processStyleWithPlugins.js
@@ -1,16 +1,19 @@
 /* @flow */
 import arrayReduce from './arrayReduce'
 
+import type NativeRenderer from '../../flowtypes/NativeRenderer'
+import type DOMRenderer from '../../flowtypes/DOMRenderer'
+
 export default function processStyleWithPlugins(
-  plugins: Array<Function>,
+  renderer: DOMRenderer | NativeRenderer,
   style: Object,
   type: number
 ) {
-  if (plugins.length > 0) {
+  if (renderer.plugins.length > 0) {
     return arrayReduce(
-      plugins,
+      renderer.plugins,
       (processedStyle, plugin) => {
-        processedStyle = plugin(processedStyle, type)
+        processedStyle = plugin(processedStyle, type, renderer)
         return processedStyle
       },
       style


### PR DESCRIPTION
**Version**: 4.x.x
**Environment**: Both
**Type**: Feature

-------------------
#### Description

It's a little bit inconvenient that there is a different workflow to handle fonts. Why not to support them everywhere and automatically render them into separate style node on the background?

<!-- 
  FEATURE REQUEST ONLY
  ====================
-->
#### Proposal

Rules could newly contain `fontFace` property.

**Code Example**:
```javascript
const rules = () => ({
  color: red,
  fontFace: {
    fontFamily: 'Lato',
    src: [ 
      'url('./fonts/Lato.ttf') format(truetype)',
      'url('./fonts/Lato.woff') format(woff)'
    ]
  }
});
```

I am not keen on the specific format but you got the idea. 

**Why this?**

- It would make possible to introduce new fonts when component is used. Now you have to do it at the root of your app globally.
- It's easier to set it up. Well, there is no extra setup.
- You don't need an instace of Fela renderer to render fonts, so you can just nicely abstract the whole Fela setup like [here](https://github.com/cloudflare/cf-ui/blob/master/packages/cf-style-provider/src/index.js#L40).
