### PR TITLE
fela-plugin-important

### DIFF
--- a/modules/plugins/__tests__/important-test.js
+++ b/modules/plugins/__tests__/important-test.js
@@ -1,0 +1,43 @@
+import important from '../important'
+
+describe('Important plugin', () => {
+  it('should add !important to every number and string', () => {
+    const style = {
+      color: 'blue',
+      fontSize: 15
+    }
+
+    expect(important()(style)).toEqual({
+      color: 'blue!important',
+      fontSize: '15!important'
+    })
+  })
+
+  it('should add !important to every value in an array', () => {
+    const style = {
+      color: 'blue',
+      fontSize: 15,
+      display: ['-webkit-flex', 'flex']
+    }
+
+    expect(important()(style)).toEqual({
+      color: 'blue!important',
+      fontSize: '15!important',
+      display: ['-webkit-flex!important', 'flex!important']
+    })
+  })
+
+  it('should add !important to nested objects', () => {
+    const style = {
+      color: 'blue',
+      fontSize: 15,
+      ':hover': { color: 'red' }
+    }
+
+    expect(important()(style)).toEqual({
+      color: 'blue!important',
+      fontSize: '15!important',
+      ':hover': { color: 'red!important' }
+    })
+  })
+})

--- a/modules/plugins/important.js
+++ b/modules/plugins/important.js
@@ -1,0 +1,32 @@
+/* @flow */
+import isObject from '../utils/isObject'
+
+function addImportantToValue(value: any): any {
+  if (
+    typeof value === 'number' ||
+    (typeof value === 'string' &&
+      value.toLowerCase().indexOf('!important') === -1)
+  ) {
+    return `${value}!important`
+  }
+
+  return value
+}
+
+function addImportant(style: Object): Object {
+  for (const property in style) {
+    const value = style[property]
+
+    if (isObject(value)) {
+      style[property] = addImportant(value)
+    } else if (Array.isArray(value)) {
+      style[property] = value.map(addImportantToValue)
+    } else {
+      style[property] = addImportantToValue(value)
+    }
+  }
+
+  return style
+}
+
+export default () => addImportant


### PR DESCRIPTION
**Version**: 4.x
**Environment**: Both
**Type**: Feature

-------------------
#### Description
Does it make sense to have an official plugin that will append `!important` to all CSS rules? It would help with specificity issues. It's doesn't seem [that crazy](https://github.com/Khan/aphrodite#disabling-important). 