### PR TITLE
Validator plugin: fix keyframe object validation

### DIFF
--- a/modules/plugins/validator.js
+++ b/modules/plugins/validator.js
@@ -6,8 +6,6 @@ import isObject from '../utils/isObject'
 import isNestedSelector from '../utils/isNestedSelector'
 import isMediaQuery from '../utils/isMediaQuery'
 
-const percentageRegex = /from|to|%/
-
 type Type = 1 | 2 | 3 | 4 | 5;
 
 function validateStyleObject(
@@ -69,7 +67,7 @@ function validateKeyframeObject(
       }
       // check for invalid percentage values, it only allows from, to or 0% - 100%
     } else if (
-      !percentageRegex.test(percentage) || !isValidPercentage(percentage)
+      percentage !== 'from' && percentage !== 'to' && !isValidPercentage(percentage)
     ) {
       if (logInvalid) {
         console.error(


### PR DESCRIPTION
Right now validator plugin prints warning if we use `to` or `from` instead of percentage:

```
validator.js:75  Invalid keyframe property.
              Expected either `to`, `from` or a percentage value between 0 and 100. 
Object {percentage: "from", style: Object}
```