### PR TITLE
react-fela: change `connect(mapStylesToProps)` to be `connect(rules)`

### DIFF
--- a/modules/bindings/connectFactory.js
+++ b/modules/bindings/connectFactory.js
@@ -6,23 +6,22 @@ export default function connectFactory(
   createElement: Function,
   contextTypes?: Object
 ): Function {
-  return function connect(mapStylesToProps: Function): Function {
+  return function connect(rules: Object): Function {
     return (component: any): any => {
       class EnhancedComponent extends BaseComponent {
         static displayName = generateDisplayName(component);
 
         render() {
-          const { renderer, theme } = this.context
+          const { renderer, theme = {} } = this.context
+          const styleProps = { ...this.props, theme }
 
-          const styles = mapStylesToProps({
-            ...this.props,
-            theme: theme || {}
-          })(renderer)
+          const styles = Object.keys(rules).reduce((sofar, key) => {
+            const style = renderer.renderRule(rules[key], styleProps)
+            return Object.assign(sofar, { [key]: style })
+          }, {})
 
-          return createElement(component, {
-            ...this.props,
-            styles
-          })
+          const props = { ...this.props, styles }
+          return createElement(component, props)
         }
       }
 


### PR DESCRIPTION
hey :cat: 

this is a proposal for a BREAKING CHANGE to `react-fela`.

the current `connect` takes a single argument `mapStylesToProps` which is a function of shape `(props) => (renderer) => styles`, where styles is an object of `className`s mapped by style name.

i propose we change `connect` to take a single argument `rules` which is an object of rules mapped by style name.

for example, the _current way_:

```js
const mapStylesToProps = (props) => (renderer) => ({
  container: renderer.renderRule(({ color }) => ({
    display: 'flex',
    flexDirection: 'column',
    alignItems: 'center',
    backgroundColor: color
  }, { color: props.color })),
  button: renderer.renderRule(() => ({
    marginTop: '20px'
  })
})

const connectedComponent = connect(mapStylesToProps)(Component)
```

the _proposed new way_:

```js
const rules = {
  container: ({ color }) => ({
    display: 'flex',
    flexDirection: 'column',
    alignItems: 'center',
    backgroundColor: color
  }),
  button: () => ({
    marginTop: '20px'
  })
})

const connectedComponent = connect(rules)(Component)
```

why?

- matches better with `createComponent` api, which takes a single rule.
- removes `renderer.renderRule` boilerplate (i'm curious, does anyone have a use case where they need to call something other than `renderer.renderRule`?)
- makes it nice and easy to have style files with fela rules _alongside_ your react components, so you can mix and match rules as you wish. (in the current way, you have rules then you have to make another function `mapStylesToProps` which is separate)

what do people think about this idea?

if people think this is a good idea, i'm happy to update the respective documentation and change the code to pass the linter.

thanks for listening. :heart: 

/cc @iainkirkpatrick