### PR TITLE
Remove font-renderer from example-react

### DIFF
--- a/packages/example-react/client.js
+++ b/packages/example-react/client.js
@@ -6,7 +6,7 @@ import App from './app'
 
 import createRenderer from './renderer'
 
-const renderer = createRenderer(document.getElementById('font-stylesheet'))
+const renderer = createRenderer()
 
 render(
   <Provider renderer={renderer}>

--- a/packages/example-react/index.html
+++ b/packages/example-react/index.html
@@ -5,7 +5,6 @@
   <meta charset="utf-8">
   <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1" />
   <!-- {{css}} -->
-  <style id="font-stylesheet"><!-- {{fonts}} --></style>
   <title>Fela - Examples</title>
 </head>
 

--- a/packages/example-react/package.json
+++ b/packages/example-react/package.json
@@ -13,7 +13,6 @@
     "fela": "^4.2.6",
     "fela-beautifier": "^4.2.6",
     "fela-dom": "^4.3.5",
-    "fela-font-renderer": "^4.2.6",
     "fela-perf": "^4.2.6",
     "fela-plugin-embedded": "^4.2.6",
     "fela-plugin-fallback-value": "^4.2.6",

--- a/packages/example-react/renderer.js
+++ b/packages/example-react/renderer.js
@@ -9,9 +9,8 @@ import logger from 'fela-plugin-logger'
 
 import perf from 'fela-perf'
 import beautifier from 'fela-beautifier'
-import fontRenderer from 'fela-font-renderer'
 
-export default fontNode => {
+export default () => {
   const renderer = createRenderer({
     plugins: [
       embedded(),
@@ -19,9 +18,10 @@ export default fontNode => {
       fallbackValue(),
       unit(),
       lvha(),
-      validator()
+      validator(),
+      logger()
     ],
-    enhancers: [perf(), beautifier(), fontRenderer(fontNode)]
+    enhancers: [perf(), beautifier()]
   })
 
   renderer.renderStatic(

--- a/packages/example-react/server.js
+++ b/packages/example-react/server.js
@@ -26,13 +26,11 @@ app.get('/', (req, res) => {
     </Provider>
   )
   const appCSS = renderToMarkup(renderer)
-  const fontCSS = renderer.fontRenderer.renderToString()
 
   res.write(
     indexHTML
       .replace('<!-- {{app}} -->', appHtml)
       .replace('<!-- {{css}} -->', appCSS)
-      .replace('<!-- {{fonts}} -->', fontCSS)
   )
   res.end()
 })


### PR DESCRIPTION
It's deprecated. 💛 