### PR TITLE
Style nodes initialization and duplication fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "babel-preset-es2015-rollup": "^1.1.1",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",
+    "beautify": "^0.0.8",
     "codeclimate-test-reporter": "^0.3.1",
     "cross-env": "^1.0.8",
     "css-in-js-utils": "^1.0.3",

--- a/packages/fela-dom/src/DOMInterface.js
+++ b/packages/fela-dom/src/DOMInterface.js
@@ -18,23 +18,23 @@ const sheetMap = {
 }
 
 export default function createDOMInterface(renderer: DOMRenderer): Function {
-  const styleNodes = reflushStyleNodes()
-  const baseNode = styleNodes[RULE_TYPE]
+  renderer.styleNodes = reflushStyleNodes()
+  const baseNode = renderer.styleNodes[RULE_TYPE]
 
   function getStyleNode(type: string, media: string = ''): Object {
     const key = type + media
 
-    if (!styleNodes[key]) {
-      styleNodes[key] = createStyleNode(type, media, baseNode)
+    if (!renderer.styleNodes[key]) {
+      renderer.styleNodes[key] = createStyleNode(type, media, baseNode)
     }
 
-    return styleNodes[key]
+    return renderer.styleNodes[key]
   }
 
   return function changeSubscription(change) {
     if (change.type === CLEAR_TYPE) {
-      for (const node in styleNodes) {
-        styleNodes[node].textContent = ''
+      for (const node in renderer.styleNodes) {
+        renderer.styleNodes[node].textContent = ''
       }
 
       return

--- a/packages/fela-dom/src/DOMInterface.js
+++ b/packages/fela-dom/src/DOMInterface.js
@@ -6,7 +6,7 @@ import {
   STATIC_TYPE,
   CLEAR_TYPE,
   reflushStyleNodes,
-  createStyleNode
+  getStyleNode
 } from 'fela-tools'
 
 import type DOMRenderer from '../../../flowtypes/DOMRenderer'
@@ -21,16 +21,6 @@ export default function createDOMInterface(renderer: DOMRenderer): Function {
   renderer.styleNodes = reflushStyleNodes()
   const baseNode = renderer.styleNodes[RULE_TYPE]
 
-  function getStyleNode(type: string, media: string = ''): Object {
-    const key = type + media
-
-    if (!renderer.styleNodes[key]) {
-      renderer.styleNodes[key] = createStyleNode(type, media, baseNode)
-    }
-
-    return renderer.styleNodes[key]
-  }
-
   return function changeSubscription(change) {
     if (change.type === CLEAR_TYPE) {
       for (const node in renderer.styleNodes) {
@@ -40,7 +30,12 @@ export default function createDOMInterface(renderer: DOMRenderer): Function {
       return
     }
 
-    const styleNode = getStyleNode(change.type, change.media)
+    const styleNode = getStyleNode(
+      renderer.styleNodes,
+      baseNode,
+      change.type,
+      change.media
+    )
 
     if (change.type === RULE_TYPE) {
       // only use insertRule in production as browser devtools might have

--- a/packages/fela-dom/src/__tests__/__snapshots__/render-test.js.snap
+++ b/packages/fela-dom/src/__tests__/__snapshots__/render-test.js.snap
@@ -1,0 +1,56 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`render should render 1`] = `
+"<html>
+
+<head>
+  <style data-fela-type=\\"FONT\\" type=\\"text/css\\">
+    @font-face {
+      font-weight: 300;
+      src: url('../Lato.ttf') format('truetype');
+      font-family: \\"Lato\\"
+    }
+  </style>
+  <style data-fela-type=\\"KEYFRAME\\" type=\\"text/css\\">
+    @-webkit-keyframes k1 {
+      0% {
+        color: yellow
+      }
+      100% {
+        color: orange
+      }
+    }
+
+    @-moz-keyframes k1 {
+      0% {
+        color: yellow
+      }
+      100% {
+        color: orange
+      }
+    }
+
+    @keyframes k1 {
+      0% {
+        color: yellow
+      }
+      100% {
+        color: orange
+      }
+    }
+  </style>
+  <style data-fela-type=\\"RULE\\" type=\\"text/css\\">
+    .a {
+      background-color: red
+    }
+
+    .b {
+      color: blue
+    }
+  </style>
+</head>
+
+<body></body>
+
+</html>"
+`;

--- a/packages/fela-dom/src/__tests__/__snapshots__/render-test.js.snap
+++ b/packages/fela-dom/src/__tests__/__snapshots__/render-test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`render should render 1`] = `
+exports[`render should create style nodes and render CSS rules 1`] = `
 "<html>
 
 <head>

--- a/packages/fela-dom/src/__tests__/render-test.js
+++ b/packages/fela-dom/src/__tests__/render-test.js
@@ -1,0 +1,22 @@
+import { html as beautify } from 'js-beautify'
+import { createRenderer } from 'fela'
+import render from '../render'
+
+describe('render', () => {
+  it('should create style nodes and render CSS rules', () => {
+    const renderer = createRenderer()
+    renderer.renderRule(() => ({
+      backgroundColor: 'red',
+      color: 'blue'
+    }))
+    renderer.renderKeyframe(() => ({
+      '0%': { color: 'yellow' },
+      '100%': { color: 'orange' }
+    }))
+    renderer.renderFont('Lato', ['../Lato.ttf'], { fontWeight: 300 })
+    render(renderer)
+    expect(
+      beautify(document.documentElement.outerHTML, { indent_size: 2 })
+    ).toMatchSnapshot()
+  })
+})

--- a/packages/fela-dom/src/initStyleNodes.js
+++ b/packages/fela-dom/src/initStyleNodes.js
@@ -1,0 +1,65 @@
+/* @flow */
+import {
+  reflushStyleNodes,
+  createStyleNode,
+  RULE_TYPE,
+  KEYFRAME_TYPE,
+  FONT_TYPE,
+  STATIC_TYPE
+} from 'fela-tools'
+
+const sheetMap = {
+  fontFaces: FONT_TYPE,
+  statics: STATIC_TYPE,
+  keyframes: KEYFRAME_TYPE,
+  rules: RULE_TYPE
+}
+
+function getStyleNode(
+  styleNodes: Object,
+  baseNode: Object,
+  type: string,
+  media: string = ''
+): Object {
+  const key = type + media
+
+  if (!styleNodes[key]) {
+    styleNodes[key] = createStyleNode(type, media, baseNode)
+  }
+
+  return styleNodes[key]
+}
+
+function initNode(
+  styleNodes: Object,
+  baseNode: Object,
+  css: string,
+  type: string,
+  media: string = ''
+): void {
+  const node = getStyleNode(styleNodes, baseNode, type, media)
+  // in case that there is a node coming from server already
+  // but rules are not matchnig
+  if (node.textContent !== css) {
+    node.textContent = css
+  }
+}
+
+export default function initStyleNodes(renderer: Object): void {
+  renderer.styleNodes = reflushStyleNodes()
+  const baseNode = renderer.styleNodes[RULE_TYPE]
+
+  for (const style in sheetMap) {
+    if (renderer[style].length > 0) {
+      initNode(renderer.styleNodes, baseNode, renderer[style], sheetMap[style])
+    }
+  }
+
+  for (const media in renderer.mediaRules) {
+    const mediaCSS = renderer.mediaRules[media]
+
+    if (mediaCSS.length > 0) {
+      initNode(renderer.styleNodes, baseNode, mediaCSS, RULE_TYPE, media)
+    }
+  }
+}

--- a/packages/fela-dom/src/initStyleNodes.js
+++ b/packages/fela-dom/src/initStyleNodes.js
@@ -1,7 +1,7 @@
 /* @flow */
 import {
   reflushStyleNodes,
-  createStyleNode,
+  getStyleNode,
   RULE_TYPE,
   KEYFRAME_TYPE,
   FONT_TYPE,
@@ -13,21 +13,6 @@ const sheetMap = {
   statics: STATIC_TYPE,
   keyframes: KEYFRAME_TYPE,
   rules: RULE_TYPE
-}
-
-function getStyleNode(
-  styleNodes: Object,
-  baseNode: Object,
-  type: string,
-  media: string = ''
-): Object {
-  const key = type + media
-
-  if (!styleNodes[key]) {
-    styleNodes[key] = createStyleNode(type, media, baseNode)
-  }
-
-  return styleNodes[key]
 }
 
 function initNode(

--- a/packages/fela-dom/src/render.js
+++ b/packages/fela-dom/src/render.js
@@ -1,6 +1,7 @@
 /* @flow */
 import createDOMInterface from './DOMInterface'
 import renderToElement from './renderToElement'
+import initStyleNodes from './initStyleNodes'
 
 import type DOMRenderer from '../../../flowtypes/DOMRenderer'
 import type DOMNode from '../../../flowtypes/DOMNode'
@@ -21,6 +22,7 @@ export default function render(
 
     renderToElement(renderer, mountNode)
   } else {
+    initStyleNodes(renderer)
     const updateInterface = createDOMInterface(renderer)
     renderer.subscribe(updateInterface)
   }

--- a/packages/fela-tools/src/__tests__/__snapshots__/createStyleNode-test.js.snap
+++ b/packages/fela-tools/src/__tests__/__snapshots__/createStyleNode-test.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Create style node should create new style nodes 1`] = `
+"<html>
+
+<head>
+  <style data-fela-type=\\"RULE\\" type=\\"text/css\\"></style>
+  <style data-fela-type=\\"RULE\\" type=\\"text/css\\" media=\\"(max-width: 800px)\\"></style>
+</head>
+
+<body></body>
+
+</html>"
+`;

--- a/packages/fela-tools/src/__tests__/createStyleNode-test.js
+++ b/packages/fela-tools/src/__tests__/createStyleNode-test.js
@@ -1,0 +1,12 @@
+import { html as beautify } from 'js-beautify'
+import createStyleNode from '../createStyleNode'
+
+describe('Create style node', () => {
+  it('should create new style nodes', () => {
+    createStyleNode('RULE')
+    createStyleNode('RULE', '(max-width: 800px)')
+    expect(
+      beautify(document.documentElement.outerHTML, { indent_size: 2 })
+    ).toMatchSnapshot()
+  })
+})

--- a/packages/fela-tools/src/__tests__/reflushStyleNodes-test.js
+++ b/packages/fela-tools/src/__tests__/reflushStyleNodes-test.js
@@ -1,0 +1,23 @@
+import reflushStyleNodes from '../reflushStyleNodes'
+
+describe('Reflush style nodes', () => {
+  it('should load and process style nodes', () => {
+    const node1 = document.createElement('style')
+    node1.setAttribute('data-fela-type', 'RULE')
+    node1.type = 'text/css'
+
+    const node2 = document.createElement('style')
+    node2.setAttribute('data-fela-type', 'RULE')
+    node2.type = 'text/css'
+    node2.media = '(max-width: 800px)'
+
+    document.head.appendChild(node1)
+    document.head.appendChild(node2)
+
+    const nodes = reflushStyleNodes()
+    expect(nodes).toEqual({
+      RULE: node1,
+      'RULE(max-width: 800px)': node2
+    })
+  })
+})

--- a/packages/fela-tools/src/getStyleNode.js
+++ b/packages/fela-tools/src/getStyleNode.js
@@ -1,0 +1,16 @@
+import createStyleNode from './createStyleNode'
+
+export default function getStyleNode(
+  styleNodes: Object,
+  baseNode: Object,
+  type: string,
+  media: string = ''
+): Object {
+  const key = type + media
+
+  if (!styleNodes[key]) {
+    styleNodes[key] = createStyleNode(type, media, baseNode)
+  }
+
+  return styleNodes[key]
+}

--- a/packages/fela-tools/src/index.js
+++ b/packages/fela-tools/src/index.js
@@ -17,6 +17,7 @@ import generateCSSRule from './generateCSSRule'
 import generateCSSSelector from './generateCSSSelector'
 import generateMonolithicClassName from './generateMonolithicClassName'
 import generateStaticReference from './generateStaticReference'
+import getStyleNode from './getStyleNode'
 import isBase64 from './isBase64'
 import isMediaQuery from './isMediaQuery'
 import isNestedSelector from './isNestedSelector'
@@ -61,6 +62,7 @@ export {
   generateCSSSelector,
   generateMonolithicClassName,
   generateStaticReference,
+  getStyleNode,
   isBase64,
   isMediaQuery,
   isNestedSelector,

--- a/packages/fela/src/createRenderer.js
+++ b/packages/fela/src/createRenderer.js
@@ -58,6 +58,7 @@ export default function createRenderer(
     // use a flat cache object with pure string references
     // to achieve maximal lookup performance and memoization speed
     cache: {},
+    styleNodes: {},
 
     renderRule(rule: Function, props: Object = {}): string {
       const processedStyle = processStyleWithPlugins(

--- a/yarn.lock
+++ b/yarn.lock
@@ -1050,6 +1050,14 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+beautify@^0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/beautify/-/beautify-0.0.8.tgz#e4ff755c2cd56727de0ccc1e6cc5d3ca0c52088d"
+  dependencies:
+    cssbeautify "^0.3.1"
+    html "^1.0.0"
+    js-beautify "^1.6.4"
+
 binary-extensions@^1.0.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.8.0.tgz#48ec8d16df4377eae5fa5884682480af4d95c774"
@@ -1071,6 +1079,10 @@ block-stream@*, block-stream@0.0.9:
   resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
   dependencies:
     inherits "~2.0.0"
+
+bluebird@^3.0.5:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.0.tgz#791420d7f551eea2897453a8a77653f96606d67c"
 
 boom@2.x.x:
   version "2.10.1"
@@ -1333,7 +1345,7 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@^1.4.10, concat-stream@^1.4.6, concat-stream@^1.5.2:
+concat-stream@^1.4.10, concat-stream@^1.4.6, concat-stream@^1.4.7, concat-stream@^1.5.2:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
   dependencies:
@@ -1341,7 +1353,7 @@ concat-stream@^1.4.10, concat-stream@^1.4.6, concat-stream@^1.5.2:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
-config-chain@~1.1.10:
+config-chain@~1.1.10, config-chain@~1.1.5:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/config-chain/-/config-chain-1.1.11.tgz#aba09747dfbe4c3e70e766a6e41586e1859fc6f2"
   dependencies:
@@ -1556,6 +1568,10 @@ css-in-js-utils@^1.0.3:
   dependencies:
     hyphenate-style-name "^1.0.2"
 
+cssbeautify@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/cssbeautify/-/cssbeautify-0.3.1.tgz#12dd1f734035c2e6faca67dcbdcef74e42811397"
+
 cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.2.tgz#b8036170c79f07a90ff2f16e22284027a243848b"
@@ -1722,6 +1738,15 @@ ecc-jsbn@~0.1.1:
 editor@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/editor/-/editor-1.0.0.tgz#60c7f87bd62bcc6a894fa8ccd6afb7823a24f742"
+
+editorconfig@^0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/editorconfig/-/editorconfig-0.13.2.tgz#8e57926d9ee69ab6cb999f027c2171467acceb35"
+  dependencies:
+    bluebird "^3.0.5"
+    commander "^2.9.0"
+    lru-cache "^3.2.0"
+    sigmund "^1.0.1"
 
 encoding@^0.1.11:
   version "0.1.12"
@@ -2607,6 +2632,12 @@ html-encoding-sniffer@^1.0.1:
   dependencies:
     whatwg-encoding "^1.0.1"
 
+html@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/html/-/html-1.0.0.tgz#a544fa9ea5492bfb3a2cca8210a10be7b5af1f61"
+  dependencies:
+    concat-stream "^1.4.7"
+
 http-signature@~1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.1.1.tgz#df72e267066cd0ac67fb76adf8e134a8fbcf91bf"
@@ -3231,6 +3262,15 @@ jodid25519@^1.0.0:
   dependencies:
     jsbn "~0.1.0"
 
+js-beautify@^1.6.4:
+  version "1.6.14"
+  resolved "https://registry.yarnpkg.com/js-beautify/-/js-beautify-1.6.14.tgz#d3b8f7322d02b9277d58bd238264c327e58044cd"
+  dependencies:
+    config-chain "~1.1.5"
+    editorconfig "^0.13.2"
+    mkdirp "~0.5.0"
+    nopt "~3.0.1"
+
 js-tokens@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
@@ -3639,6 +3679,12 @@ lru-cache@2:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.7.3.tgz#6d4524e8b955f95d4f5b58851ce21dd72fb4e952"
 
+lru-cache@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-3.2.0.tgz#71789b3b7f5399bec8565dda38aa30d2a097efee"
+  dependencies:
+    pseudomap "^1.0.1"
+
 lru-cache@^4.0.1, lru-cache@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.0.2.tgz#1d17679c069cda5d040991a09dbc2c0db377e55e"
@@ -3889,7 +3935,7 @@ node-uuid@~1.4.7:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/node-uuid/-/node-uuid-1.4.8.tgz#b040eb0923968afabf8d32fb1f17f1167fdab907"
 
-"nopt@2 || 3", nopt@~3.0.6:
+"nopt@2 || 3", nopt@~3.0.1, nopt@~3.0.6:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
   dependencies:
@@ -5014,7 +5060,7 @@ shellwords@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.0.tgz#66afd47b6a12932d9071cbfd98a52e785cd0ba14"
 
-sigmund@~1.0.0:
+sigmund@^1.0.1, sigmund@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
 


### PR DESCRIPTION
- `fela-dom/render` should mount all `<style>` nodes and rules if necessary even before the first change event is triggerd.  These cases were not covered:
  - style nodes were not server-side rendered
  - style nodes were server-side rendered but the rules don't match with browser version
- there was a weird bug when `fela-dom/render` was called twice right away (aka `react-fela`'s `<Provider>` renderered from two points of app) - it created all style nodes twice. I believe it's because the list of mounted nodes were kept in `fela-dom/render()` closure and there was some delay between adding nodes into DOM and reading them from DOM. Now, this list of mounted nodes is kept in `renderer` which should be always singleton.

~**Tests**: I'm trying to put together some tests for the style nodes initialization but so I haven't been lucky with JSDom yet. I'll try later again.~ We **still** need better coverage for `fela-dom`.