### PR TITLE
Fix format issue in renderFont

### DIFF
--- a/packages/fela-tools/src/__tests__/checkFontFormat-test.js
+++ b/packages/fela-tools/src/__tests__/checkFontFormat-test.js
@@ -3,7 +3,7 @@ import checkFontFormat from '../checkFontFormat'
 describe('Checking the font format', () => {
   it('should return the correct format', () => {
     expect(checkFontFormat('foo.ttf')).toEqual('truetype')
-    expect(checkFontFormat('foo.eot')).toEqual('eot')
+    expect(checkFontFormat('foo.eot')).toEqual('embedded-opentype')
   })
 
   it('should return an empty string', () => {

--- a/packages/fela-tools/src/__tests__/checkFontFormat-test.js
+++ b/packages/fela-tools/src/__tests__/checkFontFormat-test.js
@@ -4,9 +4,11 @@ describe('Checking the font format', () => {
   it('should return the correct format', () => {
     expect(checkFontFormat('foo.ttf')).toEqual('truetype')
     expect(checkFontFormat('foo.eot')).toEqual('embedded-opentype')
+    expect(checkFontFormat('data:application/x-font-ttf;base64,blahblahblahblahblahblah')).toEqual('truetype')
   })
 
   it('should return an empty string', () => {
     expect(checkFontFormat('foobar.png')).toEqual('')
+    expect(checkFontFormat('data:image/png;base64,blahblahblahblahblahblah')).toEqual('')
   })
 })

--- a/packages/fela-tools/src/checkFontFormat.js
+++ b/packages/fela-tools/src/checkFontFormat.js
@@ -2,7 +2,7 @@
 import warning from './warning'
 import isBase64 from './isBase64'
 
-const formats = {
+const formats: { [string]: string } = {
   '.woff': 'woff',
   '.eot': 'embedded-opentype',
   '.ttf': 'truetype',
@@ -11,7 +11,7 @@ const formats = {
   '.svgz': 'svg'
 }
 
-const base64Formats = {
+const base64Formats: { [string]: string } = {
   'image/svg+xml': 'svg',
   'application/x-font-woff': 'woff',
   'application/font-woff': 'woff',

--- a/packages/fela-tools/src/isBase64.js
+++ b/packages/fela-tools/src/isBase64.js
@@ -1,4 +1,8 @@
 /* @flow */
 export default function isBase64(property: string): boolean {
-  return property.indexOf('data:') !== -1
+  return property.charAt(0) === 'd'
+      && property.charAt(1) === 'a'
+      && property.charAt(2) === 't'
+      && property.charAt(3) === 'a'
+      && property.charAt(4) === ':'
 }


### PR DESCRIPTION
When I rendered a Base64-encoded TrueType font, fela output something like this:
```css
@font-face{font-family: Blah; src: url(data...) format('ttf')}
```

The font was not working because of the `format('ttf')` part of the output. I have traced it to the checkFontFormat.js file, which did not output [the correct format statement](https://drafts.csswg.org/css-fonts-3/#src-desc) for TTF and EOT fonts. I also used this as an opportunity to make some optimizations to the code.

This pull request:

- changes the format output for .eot fonts from "eot" to "embedded-opentype," as per the standard linked above
- changes the format output for base64-encoded TTF fonts from "ttf" to "truetype"
- adds support for .svgz file extensions
- optimizes the isBase64 function to only check the first 5 characters instead of searching the whole string
- properly parses out the MIME type from the data URI, instead of searching the string several times and risking false output when the data portion happens to contain a MIME type
- properly parses the file extension from file URLs instead of searching the string several times and risking false positives
- adds tests for checking base64-encoded fonts