### PR TITLE
add recipes for displayName HOC

### DIFF
--- a/docs/recipes/DisplayNameComponents.md
+++ b/docs/recipes/DisplayNameComponents.md
@@ -1,11 +1,11 @@
-# displayName on React Components
+# Explicit displayName for React components
 
-Sometimes, you need to have a explicit displayName on your components and not the default `FelaComponent` for debugging, or maybe for things like storybook. Right now, there isn't an automatic way to do this.
+Sometimes, you need to have an explicit displayName for your components rather than the default `FelaComponent` for debugging, or maybe for things like storybook. Right now, there is no automatic way to do this.
 
-## use a HOC
+## Using a HoC
 
-One way to handle this problem is with HOC. we recommand you to use [recompose](https://github.com/acdlite/recompose).
-When you export your components, just use the HOC [setDisplayName](https://github.com/acdlite/recompose/blob/master/docs/API.md#setdisplayname).
+One way to handle this problem is is by using a HoC. We recommend [recompose](https://github.com/acdlite/recompose).
+When you export your components, just use the HoC [setDisplayName](https://github.com/acdlite/recompose/blob/master/docs/API.md#setdisplayname).
 
 ```javascript
 
@@ -24,8 +24,8 @@ export default setDisplayName('Container')(Container)
 
 ```
 
-## More solutions in the future
+## Other solutions
 
 Like i said ealier, there is no automatic solution to handle this case right now.
-But, they are possibilities with babel plugins to help us out. The most promising one is [babel-plugin-transform-react-stateless-component-name](https://github.com/wyze/babel-plugin-transform-react-stateless-component-name)
-Right now, it can't handle HOC but people are working on it and maybe someday, will be able to let babel handle this for us.
+But, there are possibilities with babel plugins that might help out. The most promising one is [babel-plugin-transform-react-stateless-component-name](https://github.com/wyze/babel-plugin-transform-react-stateless-component-name)
+Right now, it can't handle HoCs, but people are working on it and maybe someday we'll be able to use Babel instead.

--- a/docs/recipes/DisplayNameComponents.md
+++ b/docs/recipes/DisplayNameComponents.md
@@ -1,0 +1,31 @@
+# displayName on React Components
+
+Sometimes, you need to have a explicit displayName on your components and not the default `FelaComponent` for debugging, or maybe for things like storybook. Right now, there isn't an automatic way to do this.
+
+## use a HOC
+
+One way to handle this problem is with HOC. we recommand you to use [recompose](https://github.com/acdlite/recompose).
+When you export your components, just use the HOC [setDisplayName](https://github.com/acdlite/recompose/blob/master/docs/API.md#setdisplayname).
+
+```javascript
+
+import { createComponent } from 'react-fela'
+import { setDisplayName } from 'recompose'
+
+const container = ({ padding }) => ({
+  padding: padding + 'px',
+  backgroundColor: 'rgb(124, 114, 231)',
+  fontSize: '20px'
+})
+
+const Container = createComponent(container)
+
+export default setDisplayName('Container')(Container)
+
+```
+
+## More solutions in the future
+
+Like i said ealier, there is no automatic solution to handle this case right now.
+But, they are possibilities with babel plugins to help us out. The most promising one is [babel-plugin-transform-react-stateless-component-name](https://github.com/wyze/babel-plugin-transform-react-stateless-component-name)
+Right now, it can't handle HOC but people are working on it and maybe someday, will be able to let babel handle this for us.

--- a/docs/recipes/MonoloticClassNames.md
+++ b/docs/recipes/MonoloticClassNames.md
@@ -1,6 +1,5 @@
-# Developer Experience
+# Monolithic class names
 
-## Monolithic class names
 Using atomic class names design for developing can be quite hard to debug so we support monolithic class names.
 Atomic class names will give you `n` number of classes when you `renderer.renderRule` while monolithic design will give you one class name with all the rules. By default, the class names are based on properties (it's a simple hash function). If you want to fix the class name, you can add property `className` into your rule set. This can be useful if you want to generate an external stylesheet that's human readable, deterministic and can be used on non-JS projects.
 

--- a/packages/react-fela/docs/createComponent.md
+++ b/packages/react-fela/docs/createComponent.md
@@ -90,4 +90,4 @@ ReactDOM.render(
 
 ## Related
 
-- [displayName on React Components](http://fela.js.org/docs/recipes/DisplayNameComponents.html)
+- [Explicit displayName for React components](http://fela.js.org/docs/recipes/DisplayNameComponents.html)

--- a/packages/react-fela/docs/createComponent.md
+++ b/packages/react-fela/docs/createComponent.md
@@ -87,3 +87,7 @@ ReactDOM.render(
 )
 // => <h1 className="a">Hello World</h1>
 ```
+
+## Related
+
+- [displayName on React Components](http://fela.js.org/docs/recipes/DisplayNameComponents.html)


### PR DESCRIPTION
Right now, i just remove DX and copy/paste the Monolithic section to Recipes (maybe you want to re write this part). I'm not sure about the babel plugin part in recipes, but i think it's worth mentioning that maybe there are other solutions to handle this problem.

- Add recipes for displayName HOC
- Add link to related in react-fela createComponent doc
- delete DX sections (Monolithic)
- Add recipes to match DX