### PR TITLE
docs(connect): fix mismatched prop name

### DIFF
--- a/packages/react-fela/docs/connect.md
+++ b/packages/react-fela/docs/connect.md
@@ -27,7 +27,7 @@ const container = props => ({
 
 const title = props => ({
   lineHeight: 1.2,
-  fontSize: props.fontSize,
+  fontSize: props.size,
   color: props.color
 })
 


### PR DESCRIPTION
It looks like the prop `size` is mismatched with `fontSize`.  I've normalized them here to `size`.