### PR TITLE
Update preact example and preact-fela

### DIFF
--- a/packages/example-preact/app.js
+++ b/packages/example-preact/app.js
@@ -1,8 +1,7 @@
-import React, { Component } from 'react'
+import { h } from 'preact'
 import Wrapper from './components/Wrapper'
 import Text from './components/Text'
 import Header from './components/Header'
-
 import Input from './containers/Input'
 
 export default () => (

--- a/packages/example-preact/client.js
+++ b/packages/example-preact/client.js
@@ -1,8 +1,6 @@
 import { render, h } from 'preact'
 import { Provider } from 'preact-fela'
-
 import App from './app'
-
 import createRenderer from './renderer'
 
 const renderer = createRenderer()
@@ -11,5 +9,6 @@ render(
   <Provider renderer={renderer}>
     <App />
   </Provider>,
-  document.getElementById('app')
+  document.getElementById('app'),
+  document.getElementById('app').lastElementChild
 )

--- a/packages/example-preact/components/Header.js
+++ b/packages/example-preact/components/Header.js
@@ -1,35 +1,26 @@
 import { h } from 'preact'
-import { connect } from 'preact-fela'
+import { createComponent } from 'preact-fela'
 
-const Header = ({ title, styles }) => (
-  <div className={styles}>
+const Header = ({ title, className }) => (
+  <div className={className}>
     {title}
   </div>
 )
 
-const welcome = props => ({
-  animation: `${props.name} 2s infinite`,
+const rule = () => ({
   color: 'rgb(50, 50, 50)',
   fontSize: 100,
   padding: 50,
   ':hover': { animationDuration: '500ms' },
   '@media (max-width: 800px)': { fontSize: '40px' },
-
-  // validation test
-  invalid: { color: 'blue' }
+  animationDuration: '2s',
+  animationIterationCount: 'infinite',
+  animationName: {
+    '0%': { color: 'green' },
+    '50%': { color: 'blue' },
+    '80%': { color: 'purple' },
+    '100%': { color: 'green' }
+  }
 })
 
-const animation = props => ({
-  '0%': { color: props.color },
-  '50%': { color: 'blue' },
-  '80%': { color: 'purple' },
-  '100%': { color: props.color },
-
-  // validation test
-  invalid: { color: 'blue' }
-})
-
-const mapStylesToProps = props =>
-  renderer => renderer.renderRule(welcome, { name: renderer.renderKeyframe(animation, { color: 'green' }) })
-
-export default connect(mapStylesToProps)(Header)
+export default createComponent(rule, Header, ['title'])

--- a/packages/example-preact/components/Text.js
+++ b/packages/example-preact/components/Text.js
@@ -1,6 +1,6 @@
 import { createComponent } from 'preact-fela'
 
-const info = props => ({
+const info = () => ({
   padding: 5,
   fontSize: '20px',
   color: 'gray',

--- a/packages/example-preact/components/Wrapper.js
+++ b/packages/example-preact/components/Wrapper.js
@@ -6,7 +6,13 @@ const center = props => ({
   alignItems: 'center',
   textAlign: 'center',
   flexDirection: 'column',
-  flex: props.flex || 1
+  flex: props.flex || 1,
+  fontFace: {
+    fontFamily: 'Lato',
+    src: [
+      'https://fonts.gstatic.com/s/lato/v11/qIIYRU-oROkIk8vfvxw6QvesZW2xOQ-xsNqO47m55DA.woff'
+    ]
+  }
 })
 
 export default createComponent(center)

--- a/packages/example-preact/package.json
+++ b/packages/example-preact/package.json
@@ -21,33 +21,27 @@
     "fela-plugin-prefixer": "^5.0.0",
     "fela-plugin-unit": "^5.0.0",
     "fela-plugin-validator": "^5.0.0",
-    "preact": "^7.2.0",
+    "preact": "^8.1.0",
     "preact-fela": "^5.0.0",
     "preact-render-to-string": "^3.6.0"
   },
   "devDependencies": {
-    "babel": "6.5.2",
-    "babel-cli": "6.6.0",
-    "babel-loader": "6.2.1",
-    "babel-plugin-add-module-exports": "0.1.2",
-    "babel-plugin-transform-dev-warning": "^0.1.0",
-    "babel-preset-es2015": "6.6.0",
-    "babel-preset-react": "6.5.0",
-    "babel-preset-stage-0": "6.5.0",
-    "concurrently": "^2.1.0",
+    "babel-cli": "^6.24.1",
+    "babel-loader": "^7.0.0",
+    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-react": "^6.24.1",
+    "concurrently": "^3.1.0",
     "express": "^4.14.0",
-    "express-http-proxy": "^0.7.2",
-    "webpack": "1.12.11",
-    "webpack-dev-server": "1.14.1"
+    "express-http-proxy": "^1.0.3",
+    "webpack": "^2.6.1",
+    "webpack-dev-server": "^2.4.5"
   },
   "babel": {
     "presets": [
       "es2015",
-      "stage-0",
       "react"
     ],
     "plugins": [
-      "add-module-exports",
       [
         "transform-react-jsx",
         {

--- a/packages/example-preact/package.json
+++ b/packages/example-preact/package.json
@@ -12,8 +12,9 @@
   "dependencies": {
     "fela": "^5.0.0",
     "fela-beautifier": "^5.0.0",
-    "fela-font-renderer": "^5.0.0",
+    "fela-dom": "^5.0.0",
     "fela-perf": "^5.0.0",
+    "fela-plugin-embedded": "^5.0.0",
     "fela-plugin-fallback-value": "^5.0.0",
     "fela-plugin-logger": "^5.0.0",
     "fela-plugin-lvha": "^5.0.0",

--- a/packages/example-preact/renderer.js
+++ b/packages/example-preact/renderer.js
@@ -1,19 +1,26 @@
 import { createRenderer } from 'fela'
+import embedded from 'fela-plugin-embedded'
 import prefixer from 'fela-plugin-prefixer'
 import fallbackValue from 'fela-plugin-fallback-value'
 import unit from 'fela-plugin-unit'
 import lvha from 'fela-plugin-lvha'
 import validator from 'fela-plugin-validator'
 import logger from 'fela-plugin-logger'
-
 import perf from 'fela-perf'
 import beautifier from 'fela-beautifier'
-import fontRenderer from 'fela-font-renderer'
 
-export default (fontNode) => {
+export default () => {
   const renderer = createRenderer({
-    plugins: [prefixer(), fallbackValue(), unit(), lvha(), validator()],
-    enhancers: [perf(), beautifier(), fontRenderer(fontNode)]
+    plugins: [
+      embedded(),
+      prefixer(),
+      fallbackValue(),
+      unit(),
+      lvha(),
+      validator(),
+      logger()
+    ],
+    enhancers: [perf(), beautifier()]
   })
 
   renderer.renderStatic(
@@ -28,9 +35,5 @@ export default (fontNode) => {
   )
 
   renderer.renderStatic({ display: 'flex' }, 'div')
-  renderer.renderFont('Lato', [
-    'https://fonts.gstatic.com/s/lato/v11/qIIYRU-oROkIk8vfvxw6QvesZW2xOQ-xsNqO47m55DA.woff'
-  ])
-
   return renderer
 }

--- a/packages/example-preact/server.js
+++ b/packages/example-preact/server.js
@@ -5,7 +5,6 @@ import render from 'preact-render-to-string'
 import { Provider } from 'preact-fela'
 import { renderToMarkup } from 'fela-dom'
 import fs from 'fs'
-
 import App from './app.js'
 import createRenderer from './renderer'
 

--- a/packages/example-preact/webpack.config.js
+++ b/packages/example-preact/webpack.config.js
@@ -1,4 +1,4 @@
-var path = require('path')
+const path = require('path')
 
 module.exports = {
   cache: true,
@@ -12,14 +12,23 @@ module.exports = {
     chunkFilename: '[chunkhash].js'
   },
   module: {
-    loaders: [
+    rules: [
       {
         test: /\.js$/,
-        loader: 'babel-loader'
+        loader: 'babel-loader',
+        exclude: /node_modules/,
+        options: {
+          presets: [['es2015', { modules: false }], 'react'],
+          plugins: [
+            [
+              'transform-react-jsx',
+              {
+                pragma: 'h'
+              }
+            ]
+          ]
+        }
       }
     ]
-  },
-  resolveLoader: {
-    root: path.join(__dirname, 'node_modules')
   }
 }

--- a/packages/example-preact/webpack.config.js
+++ b/packages/example-preact/webpack.config.js
@@ -1,5 +1,4 @@
 var path = require('path')
-var webpack = require('webpack')
 
 module.exports = {
   cache: true,

--- a/packages/example-react/webpack.config.js
+++ b/packages/example-react/webpack.config.js
@@ -16,6 +16,7 @@ module.exports = {
       {
         test: /\.js$/,
         loader: 'babel-loader',
+        exclude: /node_modules/,
         options: {
           presets: [['es2015', { modules: false }], 'react']
         }

--- a/packages/preact-fela/package.json
+++ b/packages/preact-fela/package.json
@@ -25,6 +25,6 @@
   "dependencies": {
     "fela": "^5.0.0",
     "fela-dom": "^5.0.0",
-    "preact": "^7.0.0"
+    "preact": "^8.0.0"
   }
 }


### PR DESCRIPTION
- update preact example:
  - strange import of React
  - not using 3rd parameter of render() to overwrite server-side rendered DOM
  - remove fontRenderer
  - use fela-plugin-embedded
  - clean up the project - make it identic to react example
  - update to the latest deps
  - fix webpack config to enable tree shaking
  - exclude node_modules from babel-loader
- update preact to v8 in preact-fela
 