### PR TITLE
Fix fela-plugin-embedded nested properties

### DIFF
--- a/packages/fela-plugin-embedded/src/__tests__/embedded-test.js
+++ b/packages/fela-plugin-embedded/src/__tests__/embedded-test.js
@@ -29,4 +29,34 @@ describe('Embedded plugin', () => {
       "@font-face{font-weight:500;src:url('foo.svg') format('svg'),url('bar.ttf') format('truetype');font-family:\"Arial\"}"
     )
   })
+
+  it('should render nested inline keyframes & fonts', () => {
+    const rule = () => ({
+      color: 'red',
+      ':hover': {
+        animationName: {
+          '0%': { color: 'red' },
+          '100%': { color: 'blue' }
+        },
+        fontFace: {
+          fontFamily: 'Arial',
+          src: ['foo.svg', 'bar.ttf'],
+          fontWeight: 500
+        }
+      }
+    })
+
+    const renderer = createRenderer({ plugins: [embedded()] })
+    renderer.renderRule(rule)
+
+    expect(renderer.rules).toEqual(
+      '.a{color:red}.b:hover{animation-name:k1}.c:hover{font-family:"Arial"}'
+    )
+    expect(renderer.keyframes).toEqual(
+      '@-webkit-keyframes k1{0%{color:red}100%{color:blue}}@-moz-keyframes k1{0%{color:red}100%{color:blue}}@keyframes k1{0%{color:red}100%{color:blue}}'
+    )
+    expect(renderer.fontFaces).toEqual(
+      "@font-face{font-weight:500;src:url('foo.svg') format('svg'),url('bar.ttf') format('truetype');font-family:\"Arial\"}"
+    )
+  })
 })

--- a/packages/fela-plugin-embedded/src/index.js
+++ b/packages/fela-plugin-embedded/src/index.js
@@ -17,10 +17,10 @@ function embedded(style: Object, type: Type, renderer: DOMRenderer): Object {
       } else {
         // TODO: warning - invalid font data
       }
-    }
-
-    if (property === 'animationName' && isObject(value)) {
+    } else if (property === 'animationName' && isObject(value)) {
       style[property] = renderer.renderKeyframe(() => value)
+    } else if (isObject(value)) {
+      embedded(value, type, renderer)
     }
   }
 


### PR DESCRIPTION
The plugin looks for `animationName` and `fontFace` only on the root level of rules.