### PR TITLE
HOTFIX: react-fela is missing fela-dom dependency

### DIFF
--- a/packages/react-fela/package.json
+++ b/packages/react-fela/package.json
@@ -25,11 +25,9 @@
   "peerDependencies": {
     "react": "*"
   },
-  "devDependencies": {
-    "fela-dom": "^5.0.2"
-  },
   "dependencies": {
     "fela": "^5.0.1",
+    "fela-dom": "^5.0.2",
     "prop-types": "^15.5.8"
   }
 }


### PR DESCRIPTION
The latest `react-fela/Provider` release is broken. [5 days ago](https://github.com/rofrischmann/fela/commit/e77fb978b4e2646b700759181dc25dc1bbba9aa5#diff-c9c30823a9ae700979a7453a93ab4cd8) fela-dom was moved to devDependcies. This needs to be published asap.

todo later: Cover all binding packages (xxx-fela) with unit tests.