### PR TITLE
Bugfix: Prevent fallback plugin to mess up fontFace src property

### DIFF
--- a/packages/fela-plugin-embedded/README.md
+++ b/packages/fela-plugin-embedded/README.md
@@ -49,6 +49,19 @@ const renderer = createRenderer({
 }
 ```
 
+It also supports base64 encoded fonts:
+
+```javascript
+{
+  fontFace: {
+    fontFamily: 'font-name',
+    src: [
+      'data:application/x-font-woff;charset=utf-8;base64,PASTE-BASE64-HERE'
+    ]
+  }
+}
+```
+
 ## License
 Fela is licensed under the [MIT License](http://opensource.org/licenses/MIT).<br>
 Documentation is licensed under [Creative Common License](http://creativecommons.org/licenses/by/4.0/).<br>

--- a/packages/fela-plugin-embedded/src/__tests__/embedded-test.js
+++ b/packages/fela-plugin-embedded/src/__tests__/embedded-test.js
@@ -59,4 +59,22 @@ describe('Embedded plugin', () => {
       "@font-face{font-weight:500;src:url('foo.svg') format('svg'),url('bar.ttf') format('truetype');font-family:\"Arial\"}"
     )
   })
+
+  it('should render base64 fonts', () => {
+    const rule = () => ({
+      fontFace: {
+        fontFamily: 'foo',
+        src: [
+          'data:application/x-font-woff;charset=utf-8;base64,d09GRgABAAAAAHwwABMAAAAA4I'
+        ],
+        fontWeight: 500
+      }
+    })
+    const renderer = createRenderer({ plugins: [embedded()] })
+    renderer.renderRule(rule)
+    expect(renderer.rules).toEqual('.a{font-family:"foo"}')
+    expect(renderer.fontFaces).toEqual(
+      '@font-face{font-weight:500;src:url(data:application/x-font-woff;charset=utf-8;base64,d09GRgABAAAAAHwwABMAAAAA4I) format(\'woff\');font-family:"foo"}'
+    )
+  })
 })

--- a/packages/fela-plugin-fallback-value/src/__tests__/fallbackValue-test.js
+++ b/packages/fela-plugin-fallback-value/src/__tests__/fallbackValue-test.js
@@ -28,4 +28,22 @@ describe('Fallback value plugin', () => {
       ':hover': { width: '-webkit-calc(20px);width:calc(20px)' }
     })
   })
+
+  it('should not touch fontFamily property', () => {
+    const style = {
+      fontFace: {
+        fontFamily: 'Arial',
+        src: ['foo.svg', 'bar.ttf']
+      },
+      ':hover': { width: ['-webkit-calc(20px)', 'calc(20px)'] }
+    }
+
+    expect(fallbackValue()(style)).toEqual({
+      fontFace: {
+        fontFamily: 'Arial',
+        src: ['foo.svg', 'bar.ttf']
+      },
+      ':hover': { width: '-webkit-calc(20px);width:calc(20px)' }
+    })
+  })
 })

--- a/packages/fela-plugin-fallback-value/src/index.js
+++ b/packages/fela-plugin-fallback-value/src/index.js
@@ -9,7 +9,7 @@ function resolveFallbackValues(style: Object): Object {
 
     if (Array.isArray(value)) {
       style[property] = resolveArrayValue(property, value)
-    } else if (isObject(value)) {
+    } else if (isObject(value) && property !== 'fontFace') {
       style[property] = resolveFallbackValues(value)
     }
   }


### PR DESCRIPTION
This combination of plugins

```js
createRenderer({ plugins: [fallbackValue(), embedded()] })
```

is breaking

```js
{
  fontFace: {
    fontFamily: 'font-name',
    src: [
      'data:application/x-font-woff;charset=utf-8;base64,PASTE-BASE64-HERE'
    ]
  }
}
```

since the fallback plugin changes `src` property.

I've also added a test for base64 into embedded plugin and mentioned the usage in its README (I did that when I thought that embedded is broken but the real cause is fallbackValue).
