### PR TITLE
Proposal: Proxy to prevent wrong props to pass down

### DIFF
--- a/docs/guides/UsageWithReact.md
+++ b/docs/guides/UsageWithReact.md
@@ -136,4 +136,5 @@ render(
 * [API reference - `Provider` ](https://github.com/rofrischmann/fela/tree/master/packages/react-fela/docs/Provider.md)
 * [API reference - `connect` ](https://github.com/rofrischmann/fela/tree/master/packages/react-fela/docs/connect.md)
 * [API reference - `createComponent` ](https://github.com/rofrischmann/fela/tree/master/packages/react-fela/docs/createComponent.md)
+* [API reference - `createComponentWithProxy` ](https://github.com/rofrischmann/fela/tree/master/packages/react-fela/docs/createComponentWithProxy.md)
 * [API reference - `ThemeProvider`](https://github.com/rofrischmann/fela/tree/master/packages/react-fela/docs/ThemeProvider.md)

--- a/packages/example-react/components/Header.js
+++ b/packages/example-react/components/Header.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { createComponent } from 'react-fela'
+import { createComponentWithProxy } from 'react-fela'
 
 const Header = ({ title, className }) => (
   <div className={className}>
@@ -23,4 +23,4 @@ const rule = () => ({
   }
 })
 
-export default createComponent(rule, Header)
+export default createComponentWithProxy(rule, Header)

--- a/packages/example-react/components/Header.js
+++ b/packages/example-react/components/Header.js
@@ -23,4 +23,4 @@ const rule = () => ({
   }
 })
 
-export default createComponent(rule, Header, ['title'])
+export default createComponent(rule, Header)

--- a/packages/fela-utils/src/extractUsedProps.js
+++ b/packages/fela-utils/src/extractUsedProps.js
@@ -1,0 +1,19 @@
+export default function extractUsedProps(rule: Function): Array<string> {
+  const handler = props => {
+    return {
+      get (target, key) {
+        if(typeof target[key] === 'object' && target[key] !== null){
+          props.push(key)
+          return target[key]
+        }
+        props.push(key)
+        return target[key]
+      }
+    }
+  }
+
+  const usedProps = []
+  const proxy = new Proxy({theme: {}}, handler(usedProps))
+  rule(proxy)
+  return usedProps
+}

--- a/packages/fela-utils/src/index.js
+++ b/packages/fela-utils/src/index.js
@@ -10,6 +10,7 @@ import cssifyKeyframe from './cssifyKeyframe'
 import cssifyMediaQueryRules from './cssifyMediaQueryRules'
 import cssifyStaticStyle from './cssifyStaticStyle'
 import extractPassThroughProps from './extractPassThroughProps'
+import extractUsedProps from './extractUsedProps'
 import generateAnimationName from './generateAnimationName'
 import generateClassName from './generateClassName'
 import generateCombinedMediaQuery from './generateCombinedMediaQuery'
@@ -30,6 +31,7 @@ import objectReduce from './objectReduce'
 import processStyleWithPlugins from './processStyleWithPlugins'
 import reflushStyleNodes from './reflushStyleNodes'
 import resolvePassThrough from './resolvePassThrough'
+import resolveUsedProps from './resolveUsedProps'
 import {
   RULE_TYPE,
   KEYFRAME_TYPE,
@@ -53,6 +55,7 @@ export {
   cssifyMediaQueryRules,
   cssifyStaticStyle,
   extractPassThroughProps,
+  extractUsedProps,
   generateAnimationName,
   generateClassName,
   generateCombinedMediaQuery,
@@ -73,6 +76,7 @@ export {
   processStyleWithPlugins,
   reflushStyleNodes,
   resolvePassThrough,
+  resolveUsedProps,
   RULE_TYPE,
   KEYFRAME_TYPE,
   FONT_TYPE,

--- a/packages/fela-utils/src/resolveUsedProps.js
+++ b/packages/fela-utils/src/resolveUsedProps.js
@@ -1,0 +1,8 @@
+export default function resolveUsedProps(props: Array<string>, src: Object) {
+  const output = []
+  for(let key in src) {
+    if(props.indexOf(key) === -1)
+      output.push(key)
+  }
+  return output
+}

--- a/packages/fela-utils/src/resolveUsedProps.js
+++ b/packages/fela-utils/src/resolveUsedProps.js
@@ -1,8 +1,9 @@
+import objectReduce from './objectReduce'
+
 export default function resolveUsedProps(props: Array<string>, src: Object) {
-  const output = []
-  for(let key in src) {
+  return objectReduce(src, (output, value, key) => {
     if(props.indexOf(key) === -1)
       output.push(key)
-  }
-  return output
+    return output
+  }, [])
 }

--- a/packages/fela/src/bindings/__tests__/createComponentFactory-test.js
+++ b/packages/fela/src/bindings/__tests__/createComponentFactory-test.js
@@ -9,6 +9,10 @@ const createComponent = createComponentFactory(createElement, {
   renderer: PropTypes.object,
   theme: PropTypes.object
 })
+const createComponentWithProxy =  createComponentFactory(createElement, {
+  renderer: PropTypes.object,
+  theme: PropTypes.object
+}, true)
 
 describe('Creating Components from Fela rules', () => {
   it('should return a Component', () => {
@@ -60,7 +64,7 @@ describe('Creating Components from Fela rules', () => {
     expect(renderer.rules).toEqual('.a{color:red}.b{font-size:16}')
   })
 
-  it('should only pass explicit props to the element', () => {
+  it('should not pass props to the element', () => {
     const rule = props => ({
       color: props.color,
       fontSize: 16
@@ -72,13 +76,15 @@ describe('Creating Components from Fela rules', () => {
     const element = component(
       {
         onClick: false,
-        onHover: true
+        onHover: true,
+        color: true,
       },
       { renderer }
     )
 
     expect(element.props.onClick).toEqual(false)
     expect(element.props.onHover).toEqual(undefined)
+    expect(element.props.color).toEqual(undefined)
   })
 
   it('should pass all props to the element', () => {
@@ -217,6 +223,246 @@ describe('Creating Components from Fela rules', () => {
       fontSize: 16
     })
     const component = createComponent(Button)
+    const renderer = createRenderer()
+    const buttonInstance = component({ is: 'button' }, { renderer })
+
+    expect(buttonInstance.type).toEqual('button')
+  })
+})
+
+
+describe('Creating Components with a Proxy for props from Fela rules', () => {
+  it('should return a Component', () => {
+    const rule = props => ({
+      color: props.color,
+      fontSize: 16
+    })
+    const component = createComponentWithProxy(rule)
+
+    expect(component).toBeInstanceOf(Function)
+  })
+
+  it('should render fela rules depending on the passed props', () => {
+    const rule = props => ({
+      color: props.color,
+      fontSize: 16
+    })
+    const component = createComponentWithProxy(rule)
+
+    const renderer = createRenderer()
+
+    const element = component({ color: 'black' }, { renderer })
+
+    expect(element.type).toEqual('div')
+
+    expect(element.props.className).toEqual('a b')
+    expect(renderer.rules).toEqual('.a{color:black}.b{font-size:16}')
+  })
+
+  it('should use the theme for static rendering by default', () => {
+    const rule = props => ({
+      color: props.theme.color,
+      fontSize: 16
+    })
+    const component = createComponentWithProxy(rule)
+    const renderer = createRenderer()
+
+    const element = component(
+      {},
+      {
+        renderer,
+        theme: { color: 'red' }
+      }
+    )
+
+    expect(element.type).toEqual('div')
+
+    expect(element.props.className).toEqual('a b')
+    expect(renderer.rules).toEqual('.a{color:red}.b{font-size:16}')
+  })
+
+  it('should not pass props used in rules to the element', () => {
+    const rule = props => ({
+      color: props.color,
+      fontSize: 16
+    })
+    const component = createComponentWithProxy(rule, 'div')
+
+    const renderer = createRenderer()
+
+    const element = component(
+      {
+        onClick: false,
+        onHover: true,
+        color: true,
+      },
+      { renderer }
+    )
+
+    expect(element.props.onClick).toEqual(false)
+    expect(element.props.onHover).toEqual(true)
+    expect(element.props.color).toEqual(undefined)
+  })
+
+  it('should pass props used in rules specified in passThroughProps to the element', () => {
+    const rule = props => ({
+      color: props.color,
+      fontSize: 16
+    })
+    const component = createComponentWithProxy(rule, 'div', ['color'])
+
+    const renderer = createRenderer()
+
+    const element = component(
+      {
+        onClick: false,
+        onHover: true,
+        color: true,
+      },
+      { renderer }
+    )
+
+    expect(element.props.onClick).toEqual(false)
+    expect(element.props.onHover).toEqual(true)
+    expect(element.props.color).toEqual(true)
+  })
+
+  it('should pass all props to the element', () => {
+    const rule = props => ({
+      color: props.color,
+      fontSize: 16
+    })
+    const component = createComponentWithProxy(rule, 'div', Object.keys)
+
+    const renderer = createRenderer()
+
+    const element = component(
+      {
+        onClick: false,
+        onHover: true
+      },
+      { renderer }
+    )
+
+    expect(element.props.onClick).toEqual(false)
+    expect(element.props.onHover).not.toEqual(undefined)
+  })
+
+  it('should only use passed props to render Fela rules', () => {
+    const rule = props => ({
+      color: props.foo && props.color,
+      fontSize: '16px'
+    })
+    const component = createComponentWithProxy(rule, 'div', ['foo'])
+
+    const renderer = createRenderer()
+
+    const element = component(
+      {
+        foo: true,
+        color: 'black'
+      },
+      { renderer }
+    )
+
+    expect(element.props.foo).toEqual(true)
+    expect(renderer.rules).toEqual('.a{color:black}.b{font-size:16px}')
+  })
+
+  it('should compose styles', () => {
+    const rule = () => ({
+      color: 'blue',
+      fontSize: '16px'
+    })
+
+    const anotherRule = () => ({
+      color: 'red',
+      lineHeight: 1.2
+    })
+
+    const Comp = createComponentWithProxy(rule)
+    const ComposedComp = createComponentWithProxy(anotherRule, Comp)
+
+    const renderer = createRenderer()
+
+    const element = ComposedComp({}, { renderer })
+    const renderedElement = element.type(element.props, { renderer })
+
+    expect(renderer.rules).toEqual(
+      '.a{color:red}.b{font-size:16px}.c{line-height:1.2}'
+    )
+    expect(renderedElement.props.className).toEqual('a b c')
+  })
+
+  it('should compose passThrough props', () => {
+    const component = createComponentWithProxy(() => ({}), 'div', Object.keys)
+    const composedComponent = createComponentWithProxy(() => ({}), component, [
+      'onClick'
+    ])
+
+    const renderer = createRenderer()
+
+    const onClick = () => true
+    const element = composedComponent({ color: 'red' }, { renderer })
+    const renderedElement = element.type(
+      {
+        ...element.props,
+        onClick
+      },
+      { renderer }
+    )
+
+    expect(renderedElement.props.color).toEqual('red')
+    expect(renderedElement.props.onClick).toEqual(onClick)
+  })
+
+  it('should only use the rule name as displayName', () => {
+    const Button = () => ({
+      color: 'red',
+      fontSize: 16
+    })
+    const component = createComponentWithProxy(Button)
+
+    expect(component.displayName).toEqual('Button')
+  })
+
+  it('should use a dev-friendly className with monolithic renderer', () => {
+    const Button = () => ({ fontSize: 16 })
+
+    const component = createComponentWithProxy(Button)
+
+    const renderer = createRenderer({
+      enhancers: [monolithic({ prettySelectors: true })]
+    })
+
+    const element = component({ color: 'black' }, { renderer })
+
+    expect(element.props.className).toEqual('Button_div__abrv9k')
+    expect(renderer.rules).toEqual('.Button_div__abrv9k{font-size:16}')
+  })
+
+  it('should use a dev-friendly className and the selectorPrefix', () => {
+    const Button = () => ({ fontSize: 16 })
+
+    const component = createComponentWithProxy(Button)
+
+    const renderer = createRenderer({
+      enhancers: [monolithic({ prettySelectors: true })],
+      selectorPrefix: 'Fela-'
+    })
+
+    const element = component({ color: 'black' }, { renderer })
+
+    expect(element.props.className).toEqual('Fela-Button_div__abrv9k')
+    expect(renderer.rules).toEqual('.Fela-Button_div__abrv9k{font-size:16}')
+  })
+
+  it('should only use the rule name as displayName', () => {
+    const Button = () => ({
+      color: 'red',
+      fontSize: 16
+    })
+    const component = createComponentWithProxy(Button)
     const renderer = createRenderer()
     const buttonInstance = component({ is: 'button' }, { renderer })
 

--- a/packages/fela/src/bindings/createComponentFactory.js
+++ b/packages/fela/src/bindings/createComponentFactory.js
@@ -1,10 +1,11 @@
 /* @flow */
-import { extractPassThroughProps, resolvePassThrough } from 'fela-utils'
+import { extractPassThroughProps, extractUsedProps, resolvePassThrough, resolveUsedProps } from 'fela-utils'
 import combineRules from '../combineRules'
 
 export default function createComponentFactory(
   createElement: Function,
-  contextTypes?: Object
+  contextTypes?: Object,
+  withProxy: boolean = false,
 ): Function {
   return function createComponent(
     rule: Function,
@@ -12,7 +13,7 @@ export default function createComponentFactory(
     passThroughProps: Array<string> | Function = []
   ): Function {
     const displayName = rule.name ? rule.name : 'FelaComponent'
-
+    const usedProps = withProxy ? extractUsedProps(rule) : {}
     const FelaComponent = (
       { children, _felaRule, passThrough = [], ...ruleProps },
       { renderer, theme }
@@ -33,11 +34,11 @@ export default function createComponentFactory(
 
         combinedRule.selectorPrefix = `${displayName}_${componentName}__`
       }
-
       // compose passThrough props from arrays or functions
       const resolvedPassThrough = [
         ...resolvePassThrough(passThroughProps, ruleProps),
-        ...resolvePassThrough(passThrough, ruleProps)
+        ...resolvePassThrough(passThrough, ruleProps),
+        ...withProxy ? resolveUsedProps(usedProps, ruleProps) : []
       ]
 
       // if the component renders into another Fela component

--- a/packages/react-fela/docs/createComponentWithProxy.md
+++ b/packages/react-fela/docs/createComponentWithProxy.md
@@ -1,0 +1,62 @@
+# `createComponentWithProxy(rule, [type], [passThroughProps])`
+
+Sometimes you need/want to pass all the props the to child element but doesn't know them all except the one you use in your rules. `createComponentWithProxy`allow you to pass all the props to the child by default except the props used in the rules.
+
+## Usage
+
+This can be used in different cases:
+- When you don't know exactly all the props you need to pass to the child.
+- If you writing a lib on top of fela and need the component to receive props without forcing the user to specify which props.
+
+
+## Example
+```javascript
+import { createComponentWithProxy } from 'react-fela'
+
+const title = props => ({
+  lineHeight: props['data-foo'] === 'bar' ? 1.2 : 1.5,
+  fontSize: props.fontSize + 'px',
+  color: props.color
+})
+
+const Title = createComponentWithProxy(title, 'div')
+
+const greet = () => alert('Hello World')
+
+ReactDOM.render(
+  <Title fontSize={23} color='red' data-foo='bar' onClick={greet}>Hello World</Title>,
+  document.getElementById('app')
+)
+// => <div className="a b c"  onclick="...">Hello World</div>
+```
+
+## Tips
+
+Sometimes you need to be able to use a props in your rules and still pass it to the child. That's why `passThroughProp` is still available in `createComponentWithProxy`. Any props pass in the `passThroughProp` will be pass to the child even if you use it in your rules's component.
+
+### Example
+## Example
+```javascript
+import { createComponentWithProxy } from 'react-fela'
+
+const title = props => ({
+  lineHeight: props['data-foo'] === 'bar' ? 1.2 : 1.5,
+  fontSize: props.fontSize + 'px',
+  color: props.color
+})
+
+const Title = createComponentWithProxy(title, 'div', ['data-foo'])
+
+const greet = () => alert('Hello World')
+
+ReactDOM.render(
+  <Title fontSize={23} color='red' data-foo='bar' onClick={greet}>Hello World</Title>,
+  document.getElementById('app')
+)
+// => <div className="a b c"  data-foo="bar" onclick="...">Hello World</div>
+```
+
+## Related
+
+- [createComponent documentation](https://github.com/rofrischmann/fela/blob/master/packages/react-fela/docs/createComponent.md)
+- [Explicit displayName for React components](http://fela.js.org/docs/recipes/DisplayNameComponents.html)

--- a/packages/react-fela/src/createComponentWithProxy.js
+++ b/packages/react-fela/src/createComponentWithProxy.js
@@ -1,0 +1,10 @@
+/* @flow */
+import { createElement } from 'react'
+import PropTypes from 'prop-types'
+
+import { createComponentFactory } from 'fela'
+
+export default createComponentFactory(createElement, {
+  renderer: PropTypes.object,
+  theme: PropTypes.object
+}, true)

--- a/packages/react-fela/src/index.js
+++ b/packages/react-fela/src/index.js
@@ -2,6 +2,7 @@
 import Provider from './Provider'
 import connect from './connect'
 import createComponent from './createComponent'
+import createComponentWithProxy from './createComponentWithProxy'
 import ThemeProvider from './ThemeProvider'
 
-export { Provider, connect, createComponent, ThemeProvider }
+export { Provider, connect, createComponent, createComponentWithProxy, ThemeProvider }


### PR DESCRIPTION
I propose to use Proxy to pass all props by default except the one used in the rules.
The passThroughtProps is still available and allow to use props in the rule and still pass it down the element (and allow retro compatibility).

The main idea behind this is that when we pass props to or component we have 2 use cases:
- pass props for the element(onClick, href, ...)
- pass props to dynamic style (flex, glow, vertical, size, ...)

If we use custom Component and not element(div, span, ...), the rule still applied since what i pass as props and do not use in my rule is probably needed in my custom Component.

I updated the example in example/react-fela with the `Header` which doesn't need to specify 'title' in passThroughtProps since it's not used in the rule.

This solution allow the use of custom component (third party lib, HOC, ...) in a much easier way.
It solves a problem with data pass down customElement that does not concern the user become they are internal logic of third party library([my use case](https://gist.github.com/wcastand/6dd9876d9a82dad3545927df53febcd6))

My main concern about proxy is performance, i read everywhere that proxies are slow. So we should probably make some benchmark or at least test on real app.


Let me know what you think about the idea ;)
Making a PR without discussing it must be a bit quick but the subject was interesting personally so i figured i should give it a go.