### PR TITLE
Bugfix: Ensure that monolithic className never starts with number

### DIFF
--- a/packages/fela-utils/src/generateMonolithicClassName.js
+++ b/packages/fela-utils/src/generateMonolithicClassName.js
@@ -17,5 +17,9 @@ export default function generateMonolithicClassName(
     val = (val * 33) ^ stringified.charCodeAt(--i)
   }
 
-  return prefix + (val >>> 0).toString(36)
+  const hashedName = (val >>> 0).toString(36)
+  if (prefix) {
+    return prefix + hashedName
+  }
+  return `f${hashedName}`
 }


### PR DESCRIPTION
Apparently you can't have className as `10h3ujg` (starting with number) unless you escape it. So, it's best to avoid it completely. 

**Simple fix:** If there's no prefix, it just adds `f` (as fela) at the beginning of hashed className. This should be a patch release since people should not rely on classNames anyway.

// This was sooo annoying bug to find since I had no clue that numbers at first position are not allowed. :)