### PR TITLE
Fix issue with blacklisted class names from ad blockers

### DIFF
--- a/packages/fela-utils/src/__tests__/generateClassName-test.js
+++ b/packages/fela-utils/src/__tests__/generateClassName-test.js
@@ -12,4 +12,9 @@ describe('Generating a className', () => {
     expect(generateClassName(1)).toEqual('a')
     expect(generateClassName(1)).toEqual('a')
   })
+
+  it('should not generate a blacklisted className', () => {
+    expect(generateClassName(28)).toEqual('ac')
+    expect(generateClassName(29)).toEqual('ae')
+  })
 })

--- a/packages/fela-utils/src/generateClassName.js
+++ b/packages/fela-utils/src/generateClassName.js
@@ -1,6 +1,7 @@
 /* @flow  */
 const chars = 'abcdefghijklmnopqrstuvwxyz'
 const charLength = chars.length
+const blackList = ['ad']
 
 export default function generateClassName(
   id: number,
@@ -11,8 +12,14 @@ export default function generateClassName(
   }
 
   // Bitwise floor as safari performs much faster https://jsperf.com/math-floor-vs-math-round-vs-parseint/55
-  return generateClassName(
+  const generatedClassName = generateClassName(
     (id / charLength) | 0,
     chars[id % charLength] + className
   )
+
+  if (blackList.indexOf(generatedClassName) > -1) {
+    return generateClassName(id + 1, className)
+  }
+
+  return generatedClassName
 }


### PR DESCRIPTION
Hello,

@smartmike and I are facing https://github.com/rofrischmann/fela/issues/314 at N26. 

Not sure if this fix is the way to go as this may cause a conflict with the next generated className? What if this function maintained its internal index with a closure? That would make it possible to just skip to next without risking a conflict.

One other way to make this issue somehow irrelevant (without actually fixing it though…) is to reverse the alphabet. This would enlarge the buffer before facing this problem.

Other possibility that would be much more bulletproof: removing or replacing the `d` from the charset. That’s odd, but that would cover that major edge case.

Other suggestion: adding an extra special character at the end to bypass class checkers.