### PR TITLE
Name created rule functions in StyleSheet tool

### DIFF
--- a/packages/fela-monolithic/src/__tests__/monolithic-test.js
+++ b/packages/fela-monolithic/src/__tests__/monolithic-test.js
@@ -163,4 +163,17 @@ describe('Monolithic enhancer', () => {
 
     expect(renderer.rules).toEqual('.colorRed_137u7ef{color:red}')
   })
+
+  it('should generate pretty selectors using ruleName if defined', () => {
+    const colorRed = () => ({ color: 'red' })
+
+    colorRed.ruleName = 'redColor'
+
+    const renderer = createRenderer({
+      enhancers: [monolithic({ prettySelectors: true })]
+    })
+    renderer.renderRule(colorRed)
+
+    expect(renderer.rules).toContain('redColor')
+  })
 })

--- a/packages/fela-monolithic/src/index.js
+++ b/packages/fela-monolithic/src/index.js
@@ -100,8 +100,8 @@ function useMonolithicRenderer(
       return ''
     }
 
-    const localRulePrefix = renderer.prettySelectors && rule.name
-      ? `${rule.name}_`
+    const localRulePrefix = renderer.prettySelectors && (rule.ruleName || rule.name)
+      ? `${rule.ruleName || rule.name}_`
       : ''
 
     const className = generateMonolithicClassName(

--- a/packages/fela-tools/src/StyleSheet.js
+++ b/packages/fela-tools/src/StyleSheet.js
@@ -10,6 +10,7 @@ export default {
           ruleSheet[ruleName] = rule
         } else {
           ruleSheet[ruleName] = () => rule
+          ruleSheet[ruleName].ruleName = ruleName
         }
 
         return ruleSheet


### PR DESCRIPTION
We use `StyleSheet`  from `fela-tools` and the functions it creates are anonymous. We use the monolithic enhancer for development and therefore some created class names don't contain their rule name. I've added support for a `ruleName` property, as functions can't be named dynamically.

**Before:**
![image](https://user-images.githubusercontent.com/1777517/28238315-d2d734fe-6948-11e7-89c4-5120a2b6d613.png)

**After:**
![image](https://user-images.githubusercontent.com/1777517/28238321-da33412a-6948-11e7-9745-b3d64c95219a.png)
