### PR TITLE
add innerRef to be filtered from createComponentWithProxy

### DIFF
--- a/packages/fela-utils/src/resolveUsedProps.js
+++ b/packages/fela-utils/src/resolveUsedProps.js
@@ -8,5 +8,5 @@ export default function resolveUsedProps(props: Array<string>, src: Object) {
       return output
     },
     []
-  ).filter(prop => prop !== 'innerRef')
+  ).filter(prop => prop !== 'innerRef' || prop !== 'is')
 }

--- a/packages/fela-utils/src/resolveUsedProps.js
+++ b/packages/fela-utils/src/resolveUsedProps.js
@@ -8,5 +8,5 @@ export default function resolveUsedProps(props: Array<string>, src: Object) {
       return output
     },
     []
-  ).filter(prop => prop !== 'innerRef' || prop !== 'is')
+  ).filter(prop => prop !== 'innerRef' && prop !== 'is')
 }

--- a/packages/fela-utils/src/resolveUsedProps.js
+++ b/packages/fela-utils/src/resolveUsedProps.js
@@ -8,5 +8,5 @@ export default function resolveUsedProps(props: Array<string>, src: Object) {
       return output
     },
     []
-  )
+  ).filter(prop => prop !== 'innerRef')
 }

--- a/packages/fela/src/bindings/__tests__/createComponentFactory-test.js
+++ b/packages/fela/src/bindings/__tests__/createComponentFactory-test.js
@@ -67,8 +67,6 @@ describe('Creating Components from Fela rules', () => {
 
     const element = component({}, { renderer })
 
-    console.log(element)
-
     expect(element.type).toEqual(Comp)
 
     expect(element.props.className).toEqual('a b')

--- a/packages/fela/src/bindings/__tests__/createComponentFactory-test.js
+++ b/packages/fela/src/bindings/__tests__/createComponentFactory-test.js
@@ -472,3 +472,24 @@ describe('Creating Components with a Proxy for props from Fela rules', () => {
     expect(buttonInstance.type).toEqual('button')
   })
 })
+
+  it('should pass props except innerRef', () => {
+    const rule = props => ({
+      color: props.color,
+      fontSize: '16px'
+    })
+    const component = createComponentWithProxy(rule, 'div')
+
+    const renderer = createRenderer()
+
+    const element = component(
+      {
+        color: 'black',
+        innerRef: () => 'test'
+      },
+      { renderer }
+    )
+
+    expect(element.props.innerRef).toEqual(undefined)
+    expect(renderer.rules).toEqual('.a{color:black}.b{font-size:16px}')
+  })


### PR DESCRIPTION
add innerRef to be filtered from createComponentWithProxy before passing props down the children.

It might be a good time to add other props that need to be filtered :)