### PR TITLE
Add Using ref with React Component to Docs

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -33,6 +33,7 @@
   * [5.2. Testing Fela Components](docs/recipes/TestingFelaComponents.md)
   * [5.3. Explicit Component displayName](docs/recipes/DisplayNameComponents.md)
   * [5.4. Monolithic Class Names](docs/recipes/MonolithicClassNames.md)
+  * [5.5. Using ref with React Component](docs/recipes/UsingRefWithReactComponent.md)
 * [6. API Reference](docs/API.md)
   * 6.1. fela
     * [6.1.1. createRenderer](docs/api/fela/createRenderer.md)

--- a/docs/Recipes.md
+++ b/docs/Recipes.md
@@ -7,3 +7,4 @@ They are kind of best practice, but might turn out opinionated.
 * [Testing Fela Components](recipes/TestingFelaComponents.md)
 * [Explicit Component displayName](recipes/DisplayNameComponents.md)
 * [Monolithic Class Names](recipes/MonolithicClassNames.md)
+* [Using ref with React Component](recipes/UsingRefWithReactComponent.md)

--- a/docs/recipes/UsingRefWithReactComponent.md
+++ b/docs/recipes/UsingRefWithReactComponent.md
@@ -1,0 +1,26 @@
+# Using ref with React Component
+
+Passing `ref` to Fela components will give a ref to the Fela
+wrapper, not to DOM node. So it's not possible to call DOM methods, like focus
+on that wrapper. To get a `ref` to wrapped DOM node, pass `innerRef` prop.
+
+```javascript
+const rules = () => ({ color: 'red' })
+const StyledInput = createComponent(rules, 'input')
+
+class Form extends Component {
+  componentDidMount() {
+    this.input.focus()
+  }
+
+  render() {
+    return (
+      <StyledInput innerRef={ref => { this.input = ref }} />
+    )
+  }
+}
+```
+
+Related Github Issues:
+[Fela](https://github.com/rofrischmann/fela/issues/190)
+[Styled Components](https://github.com/styled-components/styled-components/issues/102)


### PR DESCRIPTION
Adds a documentation page regarding React's `ref`