### PR TITLE
feat(renderFont) : Add ability to refer local fonts

### DIFF
--- a/docs/basics/Fonts.md
+++ b/docs/basics/Fonts.md
@@ -15,6 +15,7 @@ In addition to the required parameters, each font face accepts five other proper
 * `fontWeight`
 * `fontStyle`
 * `unicodeRange`
+* `localAlias` - ```String or Array<String>``` - Provides way to reference locally installed system fonts by name, if available.
 
 <br>
 

--- a/docs/basics/Renderer.md
+++ b/docs/basics/Renderer.md
@@ -102,6 +102,7 @@ const files = [
 
 renderer.renderFont('Lato', files)
 renderer.renderFont('Lato-Bold', files, { fontWeight: 'bold' })
+renderer.renderFont('Lato-Bold', files, { fontWeight: 'bold', localAlias: ['Lato Bold', 'Lato-Bold'] })
 ```
 ```CSS
 @font-face {
@@ -113,6 +114,13 @@ renderer.renderFont('Lato-Bold', files, { fontWeight: 'bold' })
 @font-face {
   font-family: 'Lato-Bold';
   src: url('./fonts/Lato.ttf') format(truetype),
+       url('./fonts/Lato.woff') format(woff);
+  font-weight: bold
+}
+@font-face {
+  font-family: 'Lato-Bold';
+  src: local('Lato Bold'), local('Lato-Bold'),
+       url('./fonts/Lato.ttf') format(truetype),
        url('./fonts/Lato.woff') format(woff);
   font-weight: bold
 }

--- a/flowtypes/FontProperties.js
+++ b/flowtypes/FontProperties.js
@@ -4,4 +4,5 @@ export type FontProperties = {
   fontWeight?: string | number,
   fontStyle?: string,
   unicodeRange?: string,
+  localAlias?: string | Array<string>,
 };

--- a/packages/fela/src/__tests__/createRenderer-test.js
+++ b/packages/fela/src/__tests__/createRenderer-test.js
@@ -326,6 +326,28 @@ describe('Renderer', () => {
 
       expect(family).toEqual('"Arial"')
     })
+    it('should return the font family when localAlias is provided as string', () => {
+      const renderer = createRenderer()
+
+      const family = renderer.renderFont(
+        'Arial',
+        ['../fonts/Arial.ttf', '../fonts/Arial.woff'],
+        { localAlias: 'Arial', fontWeight: 300 }
+      )
+
+      expect(family).toEqual('"Arial"')
+    })
+    it('should return the font family when localAlias provided as array', () => {
+      const renderer = createRenderer()
+
+      const family = renderer.renderFont(
+        'Arial',
+        ['../fonts/Arial.ttf', '../fonts/Arial.woff'],
+        { localAlias: ['Arial', 'Arial-Regular'], fontWeight: 300 }
+      )
+
+      expect(family).toEqual('"Arial"')
+    })
   })
 
   describe('Subscribing to the Renderer', () => {

--- a/packages/fela/src/createRenderer.js
+++ b/packages/fela/src/createRenderer.js
@@ -113,19 +113,31 @@ export default function createRenderer(
       properties: FontProperties = {}
     ): string {
       const fontReference = family + JSON.stringify(properties)
+      const fontLocals =
+        typeof properties.localAlias === 'string'
+          ? [properties.localAlias]
+          : properties.localAlias && properties.localAlias.constructor === Array
+            ? properties.localAlias.slice()
+            : []
 
       if (!renderer.cache.hasOwnProperty(fontReference)) {
         const fontFamily = toCSSString(family)
 
+        // remove the localAlias since we extraced the needed info
+        properties.localAlias && delete properties.localAlias
+
         // TODO: proper font family generation with error proofing
         const fontFace = {
           ...properties,
-          src: files
+          src: `${fontLocals.reduce(
+            (agg, local) => (agg += ` local(${checkFontUrl(local)}), `),
+            ''
+          )}${files
             .map(
               src =>
                 `url(${checkFontUrl(src)}) format('${checkFontFormat(src)}')`
             )
-            .join(','),
+            .join(',')}`,
           fontFamily
         }
 


### PR DESCRIPTION
Provides the feature detailed in rofrischmann/fela#333

Adds the localAlias property in options. Accepts a string or array of strings.
> It's actually one reference per font and not per font type. Have extended the options object to include this property.

@rofrischmann Please review.