### PR TITLE
Remove Reference to DX Page

### DIFF
--- a/docs/Advanced.md
+++ b/docs/Advanced.md
@@ -8,4 +8,3 @@ Now that we have learned the fundamental basics, we can go on with more advanced
 * [Global & Third-Party Styles](advanced/StaticStyle.md)
 * [Combined Rules](advanced/CombinedRules.md)
 * [Enhancers](advanced/Enhancers.md)
-* [Developer Experience](advanced/DeveloperExperience.md)


### PR DESCRIPTION
I believe this is the last remaining reference to the Developer Experience (DX) page.