### PR TITLE
Update connectFactory to account for defaultProps | Fixes #355

### DIFF
--- a/packages/fela/src/bindings/__tests__/__snapshots__/connectFactory-test.js.snap
+++ b/packages/fela/src/bindings/__tests__/__snapshots__/connectFactory-test.js.snap
@@ -11,8 +11,11 @@ Array [
         color: red
     }
 </style>",
-  <ConnectedFelaComponent>
+  <ConnectedFelaComponent
+    color="red"
+>
     <Component
+        color="red"
         styles={
             Object {
                 "rule1": "a",

--- a/packages/fela/src/bindings/__tests__/connectFactory-test.js
+++ b/packages/fela/src/bindings/__tests__/connectFactory-test.js
@@ -16,8 +16,8 @@ describe('Connect Factory for bindings', () => {
       rule1: () => ({
         padding: 1
       }),
-      rule2: () => ({
-        color: 'red'
+      rule2: props => ({
+        color: props.color
       })
     }
 
@@ -28,6 +28,10 @@ describe('Connect Factory for bindings', () => {
       </div>
     ))
 
+    MyComponent.defaultProps = {
+      color: 'red'
+    }
+
     const renderer = createRenderer()
     const wrapper = mount(<MyComponent />, {
       context: {
@@ -35,9 +39,6 @@ describe('Connect Factory for bindings', () => {
       }
     })
 
-    expect([
-      beautify(`<style>${renderer.renderToString()}</style>`),
-      toJson(wrapper)
-    ]).toMatchSnapshot()
+    expect([beautify(`<style>${renderer.renderToString()}</style>`), toJson(wrapper)]).toMatchSnapshot()
   })
 })

--- a/packages/fela/src/bindings/connectFactory.js
+++ b/packages/fela/src/bindings/connectFactory.js
@@ -11,6 +11,7 @@ export default function connectFactory(
     return (component: any): any => {
       class EnhancedComponent extends BaseComponent {
         static displayName = generateDisplayName(component)
+        static defaultProps = component.defaultProps || {}
 
         render() {
           const { renderer, theme } = this.context


### PR DESCRIPTION
I updated the connectFactory per your instruction in #355– and updated the accompanying test to show a defaultProp being set and successfully used. I don't have much experience writing tests and am not super confident if my update was correct– happy to make adjustments with your guidance.

I also gave this a test run in `example-react` by swapping out the `Header.js` component with the following:

```
import React from 'react'
import { connect } from 'react-fela'

const Header = ({ styles, title }) => <div className={styles.title}>{title}</div>

Header.defaultProps = {
  padding: 50
}

const HeaderStyles = {
  title: props => ({
    color: 'rgb(50, 50, 50)',
    fontSize: 100,
    padding: props.padding,
    ':hover': { animationDuration: '500ms' },
    '@media (max-width: 800px)': { fontSize: '40px' },
    animationDuration: '2s',
    animationIterationCount: 'infinite',
    animationName: {
      '0%': { color: 'green' },
      '50%': { color: 'blue' },
      '80%': { color: 'purple' },
      '100%': { color: 'green' }
    }
  })
}

export default connect(HeaderStyles)(Header)
```

Everything worked as expected!