### PR TITLE
Add missing TypeScript definiition for createComponentWithProxy

### DIFF
--- a/packages/fela/index.d.ts
+++ b/packages/fela/index.d.ts
@@ -509,4 +509,196 @@ declare module "react-fela" {
   export function createComponent<Props>(style: Style<Props>, base: "tspan", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
   export function createComponent<Props>(style: Style<Props>, base: "use", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
   export function createComponent<Props>(style: Style<Props>, base: "view", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+
+
+  /**
+   *
+   * @param {Style} style - style function
+   */
+  export function createComponentWithProxy<Props>(style: Style<Props>): DefaultFelaHtmlComponent<Props>;
+
+    /**
+     *
+     * @param {Style} style - style function
+     * @param {string} base - HTML element tag name
+     * @param {Array<string>} passThroughProps - A list of props that get passed to the underlying element.
+     */
+    export function createComponentWithProxy<Props, Elem extends HTMLElement>(style: Style<Props>, base: string, passThroughProps?: Array<string>): FelaHtmlComponent<Props, Elem>;
+
+    /**
+     *
+     * @param {Style} style - style function
+     * @param {FelaHtmlComponent} base - Fela component
+     * @param {Array<string>} passThroughProps - A list of props that get passed to the underlying element.
+     */
+    export function createComponentWithProxy<Props, BaseProps, Elem extends HTMLElement>(style: Style<Props>, base: FelaHtmlComponent<BaseProps, Elem>, passThroughProps?: Array<string>): FelaHtmlComponent<BaseProps & Props, Elem>;
+
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "a", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLAnchorElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "abbr", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "address", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "area", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLAreaElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "article", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "aside", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "audio", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLAudioElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "b", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "base", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLBaseElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "bdi", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "bdo", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "big", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "blockquote", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "body", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLBodyElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "br", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLBRElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "button", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLButtonElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "canvas", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLCanvasElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "caption", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "cite", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "code", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "col", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLTableColElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "colgroup", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLTableColElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "data", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "datalist", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLDataListElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "dd", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "del", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "details", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "dfn", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "dialog", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "div", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLDivElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "dl", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLDListElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "dt", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "em", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "embed", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLEmbedElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "fieldset", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLFieldSetElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "figcaption", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "figure", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "footer", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "form", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLFormElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "h1", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLHeadingElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "h2", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLHeadingElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "h3", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLHeadingElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "h4", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLHeadingElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "h5", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLHeadingElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "h6", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLHeadingElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "head", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLHeadElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "header", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "hgroup", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "hr", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLHRElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "html", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLHtmlElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "i", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "iframe", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLIFrameElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "img", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLImageElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "input", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLInputElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "ins", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLModElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "kbd", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "keygen", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "label", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLLabelElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "legend", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLLegendElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "li", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLLIElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "link", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLLinkElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "main", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "map", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLMapElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "mark", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "menu", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "menuitem", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "meta", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLMetaElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "meter", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "nav", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "noindex", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "noscript", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "object", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLObjectElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "ol", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLOListElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "optgroup", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLOptGroupElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "option", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLOptionElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "output", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "p", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLParagraphElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "param", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLParamElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "picture", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLPictureElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "pre", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLPreElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "progress", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLProgressElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "q", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLQuoteElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "rp", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "rt", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "ruby", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "s", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "samp", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "script", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "section", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "select", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLSelectElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "small", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "source", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLSourceElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "span", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLSpanElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "strong", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "style", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLStyleElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "sub", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "summary", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "sup", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "table", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLTableElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "tbody", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLTableSectionElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "td", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLTableDataCellElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "textarea", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLTextAreaElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "tfoot", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLTableSectionElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "th", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLTableHeaderCellElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "thead", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLTableSectionElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "time", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "title", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLTitleElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "tr", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLTableRowElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "track", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLTrackElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "u", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "ul", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLUListElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "var", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "video", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLVideoElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "wbr", passThroughProps?: PassThroughProps): FelaHtmlComponent<Props, HTMLElement>;
+
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "svg", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "circle", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "clipPath", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "defs", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "desc", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "ellipse", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "feBlend", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "feColorMatrix", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "feComponentTransfer", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "feComposite", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "feConvolveMatrix", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "feDiffuseLighting", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "feDisplacementMap", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "feDistantLight", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "feFlood", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "feFuncA", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "feFuncB", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "feFuncG", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "feFuncR", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "feGaussianBlur", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "feImage", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "feMerge", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "feMergeNode", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "feMorphology", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "feOffset", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "fePointLight", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "feSpecularLighting", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "feSpotLight", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "feTile", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "feTurbulence", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "filter", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "foreignObject", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "g", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "image", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "line", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "linearGradient", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "marker", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "mask", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "metadata", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "path", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "pattern", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "polygon", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "polyline", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "radialGradient", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "rect", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "stop", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "switch", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "symbol", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "text", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "textPath", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "tspan", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "use", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
+    export function createComponentWithProxy<Props>(style: Style<Props>, base: "view", passThroughProps?: PassThroughProps): FelaSvgComponent<Props, SVGElement>;
 }


### PR DESCRIPTION
My experience with TypeScript is very close to `Math.min(0.1)` but as I can see `createComponentWithProxy` definition is the same as `createComponent`. While I don't know if there is any way to *clone* definition I decided to simply duplicate it.

It works with exposed public API like `createComponentWithProxy(rule, [type],[passThroughProps])`.

Thank you!