### PR TITLE
Accept stateless components in createComponent(WithProxy)

### DIFF
--- a/packages/fela/index.d.ts
+++ b/packages/fela/index.d.ts
@@ -305,12 +305,12 @@ declare module "react-fela" {
    *
    * @see {@link https://github.com/rofrischmann/fela/blob/master/modules/bindings/createComponentFactory.js#L15-L82}
    */
-  type FelaHtmlComponent<Props, Elem> = React.ComponentClass<Props & FelaInjectedProps & React.HTMLProps<Elem>>;
+  type FelaHtmlComponent<Props, Elem> = React.ComponentType<Props & FelaInjectedProps & React.HTMLProps<Elem>>;
 
   /**
    * Returns a stateless SVG React component with Fela styles.
    */
-  type FelaSvgComponent<Props, Elem extends SVGElement> = React.ComponentClass<Props & FelaInjectedProps & React.SVGAttributes<Element>>;
+  type FelaSvgComponent<Props, Elem extends SVGElement> = React.ComponentType<Props & FelaInjectedProps & React.SVGAttributes<Element>>;
 
   /**
    * By default, Fela returns a `div` stateless React component.


### PR DESCRIPTION
Right now there is no way to use stateless components with `createComponent`.

![screen shot 2017-09-12 at 10 43 09](https://user-images.githubusercontent.com/80960/30317006-2fd31612-97a9-11e7-89d5-f8de3bc15f78.png)

With this small change we can achieve that :)

`React.ComponentType` is just `React.ComponentClass<P> | React.StatelessComponent<P>` so we're good (I think ;))

Thank you!