### PR TITLE
Use real cursor value in rtl README

### DIFF
--- a/packages/fela-plugin-rtl/README.md
+++ b/packages/fela-plugin-rtl/README.md
@@ -30,7 +30,7 @@ const renderer = createRenderer({
 {
   paddingLeft: 20,
   marginRight: '25px',
-  cursor: 'w',
+  cursor: 'w-resize',
   textShadow: 'red 2px 0'
 }
 ```
@@ -39,7 +39,7 @@ const renderer = createRenderer({
 {
   paddingRight: 20,
   marginleft: '25px',
-  cursor: 'e',
+  cursor: 'e-resize',
   textShadow: 'red -2px 0'
 }
 ```


### PR DESCRIPTION
`e` isn't a real cursor value ¯\\\_(ツ)\_/¯