### PR TITLE
Remove shouldComponentUpdate from ThemeProviderFactory

### DIFF
--- a/packages/fela-bindings/src/ThemeProviderFactory.js
+++ b/packages/fela-bindings/src/ThemeProviderFactory.js
@@ -25,10 +25,6 @@ export default function ThemeProviderFactory(
       }
     }
 
-    shouldComponentUpdate(nextProps: Object): boolean {
-      return !shallowEqual(this.props.theme, nextProps.theme)
-    }
-
     getChildContext(): Object {
       return {
         theme: this.theme


### PR DESCRIPTION
ThemeProvider currently prevents any updates, by only checking for theme prop in shouldComponentUpdate.
By removing scu, ThemeProvider can be used nested inside the Component hierarchy.
