### PR TITLE
Make preset-web configurable

### DIFF
--- a/packages/fela-preset-dev/README.md
+++ b/packages/fela-preset-dev/README.md
@@ -31,6 +31,25 @@ const renderer = createRenderer({
 })
 ```
 
+You can also pass options to the plugins:
+```javascript
+import { createRenderer } from 'fela'
+import {createDevPreset} from 'fela-preset-dev'
+
+const renderer = createRenderer({
+  plugins: [
+    ...createDevPreset({
+      'fela-plugin-validator': [
+        {
+          logInvalid: true,
+          deleteInvalid: true
+        }
+      ]
+    })
+  ]
+})
+```
+
 ## License
 Fela is licensed under the [MIT License](http://opensource.org/licenses/MIT).<br>
 Documentation is licensed under [Creative Common License](http://creativecommons.org/licenses/by/4.0/).<br>

--- a/packages/fela-preset-dev/src/__tests__/index.js
+++ b/packages/fela-preset-dev/src/__tests__/index.js
@@ -1,0 +1,40 @@
+import { createRenderer } from 'fela'
+
+import devPreset, { createDevPreset } from '../index'
+
+describe('fela-preset-dev', () => {
+  it('should work without config', () => {
+    const renderer = createRenderer({
+      plugins: [...devPreset]
+    })
+    const logger = jest
+      .spyOn(global.console, 'log')
+      .mockImplementation(() => {})
+    renderer.renderRule(() => ({ color: 'red' }))
+    expect(logger).toHaveBeenCalled()
+    logger.mockClear()
+  })
+
+  it('should allow per plugin configuration', () => {
+    const configuredPreset = createDevPreset({
+      'fela-plugin-validator': [
+        {
+          logInvalid: false
+        }
+      ]
+    })
+    const logger = jest
+      .spyOn(global.console, 'error')
+      .mockImplementation(() => {})
+    const renderer = createRenderer({
+      plugins: [...configuredPreset]
+    })
+    renderer.renderRule(() => ({
+      nested: {
+        color: 'yellow'
+      }
+    }))
+    expect(logger).not.toHaveBeenCalled()
+    logger.mockClear()
+  })
+})

--- a/packages/fela-preset-dev/src/index.js
+++ b/packages/fela-preset-dev/src/index.js
@@ -2,9 +2,20 @@
 import logger from 'fela-plugin-logger'
 import validator from 'fela-plugin-validator'
 
-export default [
-  logger({
-    logMetaData: true
-  }),
-  validator()
-]
+type Config = {
+  'fela-plugin-logger'?: Array<*>,
+  'fela-plugin-validator'?: Array<*>
+}
+
+export const createDevPreset = (
+  {
+    'fela-plugin-logger': loggerConf = [
+      {
+        logMetaData: true
+      }
+    ],
+    'fela-plugin-validator': validatorConf = []
+  }: Config = {}
+) => [logger(...loggerConf), validator(...validatorConf)]
+
+export default createDevPreset()

--- a/packages/fela-preset-web/README.md
+++ b/packages/fela-preset-web/README.md
@@ -34,6 +34,25 @@ const renderer = createRenderer({
 })
 ```
 
+You can also pass options to the plugins:
+```javascript
+import { createRenderer } from 'fela'
+import {createWebPreset} from 'fela-preset-web'
+
+const renderer = createRenderer({
+  plugins: [
+    ...createWebPreset({
+          'fela-plugin-unit': [
+            'em',
+            {
+              margin: '%'
+            }
+          ]
+        })
+  ]
+})
+```
+
 ## License
 Fela is licensed under the [MIT License](http://opensource.org/licenses/MIT).<br>
 Documentation is licensed under [Creative Common License](http://creativecommons.org/licenses/by/4.0/).<br>

--- a/packages/fela-preset-web/package.json
+++ b/packages/fela-preset-web/package.json
@@ -20,11 +20,14 @@
   "author": "Robin Frischmann",
   "license": "MIT",
   "dependencies": {
-    "fela-plugin-embedded": "^5.1.7",
-    "fela-plugin-extend": "^6.0.0",
-    "fela-plugin-fallback-value": "^5.0.13",
-    "fela-plugin-lvha": "^5.0.12",
-    "fela-plugin-prefixer": "^5.0.13",
-    "fela-plugin-unit": "^5.0.12"
+    "fela-plugin-embedded": "^5.1.6",
+    "fela-plugin-extend": "^5.0.11",
+    "fela-plugin-fallback-value": "^5.0.12",
+    "fela-plugin-lvha": "^5.0.11",
+    "fela-plugin-prefixer": "^5.0.12",
+    "fela-plugin-unit": "^5.0.11"
+  },
+  "devDependencies": {
+    "fela-combine-arrays": "^1.0.2"
   }
 }

--- a/packages/fela-preset-web/src/__tests__/presetWeb-test.js
+++ b/packages/fela-preset-web/src/__tests__/presetWeb-test.js
@@ -1,0 +1,54 @@
+import { createRenderer } from 'fela'
+import combineArrays from 'fela-combine-arrays'
+
+import webPreset, { createWebPreset } from '../index'
+
+describe('preset-web-plugin', () => {
+  it('should work without config', () => {
+    const renderer = createRenderer({
+      plugins: [...webPreset],
+      enhancers: [combineArrays()]
+    })
+
+    const rule = () => ({
+      color: 'red',
+      extend: {
+        condition: true,
+        style: {
+          border: 'none'
+        }
+      }
+    })
+
+    renderer.renderRule(rule)
+    // Tests that fela-plugin-extend is added to the plugins
+    expect(renderer.rules).toEqual('.a{color:red}.b{border:none}')
+  })
+
+  describe('configuration', () => {
+    const renderer = createRenderer({
+      plugins: [
+        ...createWebPreset({
+          'fela-plugin-unit': [
+            'em',
+            {
+              margin: '%'
+            }
+          ]
+        })
+      ],
+      enhancers: [combineArrays()]
+    })
+
+    it('should allow per plugin configuration', () => {
+      renderer.renderRule(() => ({ width: 1 }))
+      expect(renderer.rules).toBe('.a{width:1em}')
+    })
+
+    it('should pass all parameters to the plugins', () => {
+      renderer.clear()
+      renderer.renderRule(() => ({ margin: 1 }))
+      expect(renderer.rules).toBe('.a{margin:1%}')
+    })
+  })
+})

--- a/packages/fela-preset-web/src/index.js
+++ b/packages/fela-preset-web/src/index.js
@@ -6,11 +6,30 @@ import fallbackValue from 'fela-plugin-fallback-value'
 import LVHA from 'fela-plugin-lvha'
 import unit from 'fela-plugin-unit'
 
-export default [
-  extend(),
-  embedded(),
-  prefixer(),
-  fallbackValue(),
-  LVHA(),
-  unit()
+type Config = {
+  'fela-plugin-extend'?: Array<*>,
+  'fela-plugin-embedded'?: Array<*>,
+  'fela-plugin-prefixer'?: Array<*>,
+  'fela-plugin-fallback-value'?: Array<*>,
+  'fela-plugin-lvha'?: Array<*>,
+  'fela-plugin-unit'?: Array<*>
+}
+export const createWebPreset = (
+  {
+    'fela-plugin-extend': extendConf = [],
+    'fela-plugin-embedded': embeddedConf = [],
+    'fela-plugin-prefixer': prefixerConf = [],
+    'fela-plugin-fallback-value': fallbackValueConf = [],
+    'fela-plugin-lvha': lvhaConf = [],
+    'fela-plugin-unit': unitConf = []
+  }: Config = {}
+) => [
+  extend(...extendConf),
+  embedded(...embeddedConf),
+  prefixer(...prefixerConf),
+  fallbackValue(...fallbackValueConf),
+  LVHA(...lvhaConf),
+  unit(...unitConf)
 ]
+
+export default createWebPreset()


### PR DESCRIPTION
Makes it possible to pass options to `fela-preset-web`. I made `createWebPreset` ignorant of the options of each plugins (hence spread and the default array), if you'd prefer me to make it explicit, it's doable.

#### Patch
- fela-preset-web
- fela-preset-dev