### PR TITLE
Multiple fontFace for single fontFamily

### DIFF
--- a/packages/fela-plugin-embedded/src/__tests__/embedded-test.js
+++ b/packages/fela-plugin-embedded/src/__tests__/embedded-test.js
@@ -113,6 +113,33 @@ describe('Embedded plugin', () => {
     )
   })
 
+  it('should render inline fonts with same fontFamily', () => {
+    const rule = () => ({
+      color: 'red',
+      fontFace: [
+        {
+          fontFamily: 'Arial',
+          src: ['arial-regular.svg', 'arial-regular.ttf'],
+          fontWeight: 400
+        },
+        {
+          fontFamily: 'Arial',
+          src: ['arial-bold.svg', 'arial-bold.ttf'],
+          fontWeight: 700
+        }
+      ]
+    })
+
+    const renderer = createRenderer({
+      plugins: [embedded()]
+    })
+    renderer.renderRule(rule)
+
+    expect(renderToString(renderer)).toBe(
+      "@font-face{font-weight:400;src:url('arial-regular.svg') format('svg'),url('arial-regular.ttf') format('truetype');font-family:\"Arial\"}@font-face{font-weight:700;src:url('arial-bold.svg') format('svg'),url('arial-bold.ttf') format('truetype');font-family:\"Arial\"}.a{color:red}.b{font-family:\"Arial\"}"
+    )
+  })
+
   it('should render base64 fonts', () => {
     const rule = () => ({
       fontFace: {

--- a/packages/fela-plugin-embedded/src/index.js
+++ b/packages/fela-plugin-embedded/src/index.js
@@ -1,5 +1,5 @@
 /* @flow */
-import { isObject } from 'fela-utils'
+import { isObject, arrayReduce } from 'fela-utils'
 
 import type DOMRenderer from '../../../flowtypes/DOMRenderer'
 
@@ -19,11 +19,19 @@ function embedded(style: Object, type: Type, renderer: DOMRenderer): Object {
 
     if (property === 'fontFace' && typeof value === 'object') {
       if (Array.isArray(value)) {
-        style.fontFamily = value
-          .map(fontFace => renderFontFace(fontFace, renderer))
-          // we filter font faces to remove invalid formats
-          .filter(fontFace => fontFace)
-          .join(',')
+        style.fontFamily = arrayReduce(
+          value,
+          (fontFamilyList, fontFace) => {
+            const fontFamily = renderFontFace(fontFace, renderer)
+
+            if (fontFamily && fontFamilyList.indexOf(fontFamily) === -1) {
+              fontFamilyList.push(fontFamily)
+            }
+
+            return fontFamilyList
+          },
+          []
+        ).join(',')
       } else {
         style.fontFamily = renderFontFace(value, renderer)
       }


### PR DESCRIPTION
closes #437

<!------------------------------------------
  Thanks for contributing!
  Please read the guide-lines at the bottom.
------------------------------------------->

## Description
Adds support for multiple fontFace values as arrays when using fela-plugin-embedded.

## Example

```javascript
const rule = () => ({
  fontFace: [
    {
      fontFamily: 'Arial',
      src: ['arial-regular.svg', 'arial-regular.ttf'],
      fontWeight: 400
    },
    {
      fontFamily: 'Arial',
      src: ['arial-bold.svg', 'arial-bold.ttf'],
      fontWeight: 700
    }
  ]
})

// => a b
// .a{color:red}.b{font-family: "Arial"}
```

## Versioning
<!------------------------------------------
  Please add all updated packages and propose new versions following the semantic versioning guidelines
------------------------------------------->


#### Major

#### Minor

#### Patch
* fela-plugin-embedded

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [ ] The code was formatted using Prettier (`yarn run format`)
- [ ] The code has no linting errors (`yarn run lint`)
- [ ] All tests are passing (`yarn run test`) 
- [ ] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [ ] Tests have been added/updated
- [ ] Documentation has been added/updated
- [ ] My changes have proper flow-types