### PR TITLE
Add option to auto passthrough extra props in "createComponentFactory"

### DIFF
--- a/packages/fela-bindings/README.md
+++ b/packages/fela-bindings/README.md
@@ -1,7 +1,7 @@
 # fela-bindings
 
-fela-bindings is a private package and is only intended for advanced use. While it does follow the semVer
-convention, it's API is undocumented and may change without prior notice.
+fela-bindings is a private package and is only intended for advanced use. While it follows
+semantic versioning, it's API is undocumented and may change without prior notice.
 
 
 ## License

--- a/packages/fela-bindings/README.md
+++ b/packages/fela-bindings/README.md
@@ -1,6 +1,7 @@
 # fela-bindings
 
-fela-bindings is a private package for Fela and should only be used interally.
+fela-bindings is a private package and is only intended for advanced use. While it does follow the semVer
+convention, it's API is undocumented and may change without prior notice.
 
 
 ## License

--- a/packages/fela-bindings/src/__tests__/__snapshots__/createComponentFactory-test.js.snap
+++ b/packages/fela-bindings/src/__tests__/__snapshots__/createComponentFactory-test.js.snap
@@ -331,6 +331,67 @@ Array [
 ]
 `;
 
+exports[`Creating Components from Fela rules should pass extended special props to the component 1`] = `
+Array [
+  "<style>
+    .a {
+        color: red
+    }
+
+    .b {
+        font-size: 16
+    }
+</style>",
+  <rule
+    color="blue"
+    testProp={
+        Object {
+            "tabIndex": "-1",
+          }
+    }
+>
+    <rule
+        color="blue"
+        testProp={
+            Object {
+                "tabIndex": "-1",
+              }
+        }
+        theme={Object {}}
+    >
+        <UnderlyingComp
+            className="a b"
+            testProp={
+                Object {
+                    "tabIndex": "-1",
+                  }
+            }
+        >
+            <div>
+                testProp exists
+            </div>
+        </UnderlyingComp>
+    </rule>
+</rule>,
+  <rule
+    color="blue"
+>
+    <rule
+        color="blue"
+        theme={Object {}}
+    >
+        <UnderlyingComp
+            className="a b"
+        >
+            <div>
+                testProp does not exist
+            </div>
+        </UnderlyingComp>
+    </rule>
+</rule>,
+]
+`;
+
 exports[`Creating Components from Fela rules should pass special props to the component 1`] = `
 Array [
   "<style>

--- a/packages/fela-bindings/src/__tests__/createComponentFactory-test.js
+++ b/packages/fela-bindings/src/__tests__/createComponentFactory-test.js
@@ -20,6 +20,14 @@ const createComponent = createComponentFactory(createElement, withTheme, {
   renderer: PropTypes.object
 })
 
+const createComponentWithExtraPassThrough = createComponentFactory(
+  createElement,
+  withTheme,
+  { renderer: PropTypes.object },
+  false,
+  ['testProp']
+)
+
 const createComponentWithProxy = createComponentFactory(
   createElement,
   withTheme,
@@ -199,6 +207,41 @@ describe('Creating Components from Fela rules', () => {
         renderer
       }
     })
+
+    const wrapper2 = mount(<Component color="blue" />, {
+      context: {
+        renderer
+      }
+    })
+
+    expect([
+      beautify(`<style>${renderToString(renderer)}</style>`),
+      toJson(wrapper),
+      toJson(wrapper2)
+    ]).toMatchSnapshot()
+  })
+
+  it.only('should pass extended special props to the component', () => {
+    const rule = props => ({
+      color: props.as === 'i' ? props.color : 'red',
+      fontSize: 16
+    })
+
+    const UnderlyingComp = ({ testProp }) => (
+      <div>{testProp ? 'testProp exists' : 'testProp does not exist'}</div>
+    )
+    const Component = createComponentWithExtraPassThrough(rule, UnderlyingComp)
+    // const Component = createComponentWithExtraPassThrough(rule, UnderlyingComp)
+    const renderer = createRenderer()
+
+    const wrapper = mount(
+      <Component color="blue" testProp={{ tabIndex: '-1' }} />,
+      {
+        context: {
+          renderer
+        }
+      }
+    )
 
     const wrapper2 = mount(<Component color="blue" />, {
       context: {

--- a/packages/fela-bindings/src/connectFactory.js
+++ b/packages/fela-bindings/src/connectFactory.js
@@ -16,12 +16,14 @@ export default function connectFactory(
         render() {
           const { renderer } = this.context
 
-          const preparedRules = typeof rules === 'function' ? rules(this.props) : rules
+          const preparedRules =
+            typeof rules === 'function' ? rules(this.props) : rules
 
           const styles = objectReduce(
             preparedRules,
             (styleMap, rule, name) => {
-              const preparedRule = typeof rule !== 'function' ? () => rule : rule
+              const preparedRule =
+                typeof rule !== 'function' ? () => rule : rule
               styleMap[name] = renderer.renderRule(preparedRule, this.props)
               return styleMap
             },

--- a/packages/fela-bindings/src/createComponentFactory.js
+++ b/packages/fela-bindings/src/createComponentFactory.js
@@ -12,7 +12,8 @@ export default function createComponentFactory(
   createElement: Function,
   withTheme: Function,
   contextTypes?: Object,
-  withProxy: boolean = false
+  withProxy: boolean = false,
+  alwaysPassThroughProps: string[] = []
 ): Function {
   return function createComponent(
     rule: Function,
@@ -65,6 +66,7 @@ export default function createComponentFactory(
       }
       // compose passThrough props from arrays or functions
       const resolvedPassThrough = [
+        ...alwaysPassThroughProps,
         ...resolvePassThrough(passThroughProps, otherProps),
         ...resolvePassThrough(passThrough, otherProps),
         ...(withProxy ? resolveUsedProps(usedProps, otherProps) : [])


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guide-lines at the bottom.
------------------------------------------->

## Description
Add a param to `createComponentFactory` allowing to specify props that will be automatically passed to underlying components in `createComponent`

## Versioning
<!------------------------------------------
  Please add all updated packages and propose new versions following the semantic versioning guidelines
------------------------------------------->


#### Major

#### Minor
fela-bindings

#### Patch

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

