### PR TITLE
[TypeScript] Fix combineRules() typings

### DIFF
--- a/packages/fela/index.d.ts
+++ b/packages/fela/index.d.ts
@@ -3,7 +3,7 @@ declare module "fela" {
   import { CSSProperties } from 'react';
 
   type TRuleProps = {};
-  type TRule = (props: TRuleProps) => IStyle;
+  type TRule<T = TRuleProps> = (props: T) => IStyle
   type TKeyFrame = TRule;
   type TRendererCreator = (config?: IConfig) => IRenderer;
   type TPlugin = (style: IStyle) => IStyle; //http://fela.js.org/docs/advanced/Plugins.html
@@ -27,7 +27,7 @@ declare module "fela" {
   interface ISubscribeClearMessage extends ISubscribeMessage { }
 
   interface IRenderer {
-    renderRule(rule: TRule, props: TRuleProps): string;
+    renderRule<T = TRuleProps>(rule: TRule<T>, props: T): string
     renderKeyframe(keyFrame: TKeyFrame, props: TRuleProps): string;
     renderFont(family: string, files: Array<string>, props: TRuleProps): void;
     renderStatic(style: string, selector?: string): void;
@@ -51,7 +51,13 @@ declare module "fela" {
   }
 
   function createRenderer(config?: IConfig): IRenderer;
-  function combineRules(...rules: Array<TRule>): TRule;
+  function combineRules<A, B>(a: TRule<A>, b: TRule<B>): TRule<A & B>
+  function combineRules<A, B, C>(
+    a: TRule<A>,
+    b: TRule<B>,
+    c: TRule<C>,
+  ): TRule<A & B & C>
+  function combineRules(...rules: Array<TRule>): TRule
   function enhance(...enhancers: Array<TEnhancer>): (rendererCreator: TRendererCreator) => TRendererCreator;
 }
 


### PR DESCRIPTION
Closes #377 

__Error 1 caught:__

<img width="540" alt="image" src="https://user-images.githubusercontent.com/767070/32865541-2e9464c4-ca29-11e7-9226-eac31fdbd41d.png">

__Error 2 caught:__

<img width="504" alt="image" src="https://user-images.githubusercontent.com/767070/32865567-4792bc50-ca29-11e7-8664-83c14fef5f26.png">

__All good__

<img width="356" alt="image" src="https://user-images.githubusercontent.com/767070/32865579-537069a0-ca29-11e7-94d5-eb1b7e4cfc4b.png">
