### PR TITLE
Use scoped keys for Theming

### DIFF
--- a/packages/fela-bindings/src/ThemeProviderFactory.js
+++ b/packages/fela-bindings/src/ThemeProviderFactory.js
@@ -3,6 +3,7 @@ import isEqual from 'lodash/isEqual'
 import forEach from 'lodash/forEach'
 
 import createTheme from './createTheme'
+import { THEME_CHANNEL } from './themeChannel'
 
 export default function ThemeProviderFactory(
   BaseComponent: any,
@@ -15,7 +16,7 @@ export default function ThemeProviderFactory(
     constructor(props: Object, context: Object) {
       super(props, context)
 
-      const previousTheme = !props.overwrite && this.context.theme
+      const previousTheme = !props.overwrite && this.context[THEME_CHANNEL]
       this.theme = createTheme(props.theme, previousTheme)
     }
 
@@ -27,7 +28,7 @@ export default function ThemeProviderFactory(
 
     getChildContext(): Object {
       return {
-        theme: this.theme,
+        [THEME_CHANNEL]: this.theme,
       }
     }
 

--- a/packages/fela-bindings/src/__tests__/ThemeProviderFactory-test.js
+++ b/packages/fela-bindings/src/__tests__/ThemeProviderFactory-test.js
@@ -5,9 +5,10 @@ import toJson from 'enzyme-to-json'
 
 import withThemeFactory from '../withThemeFactory'
 import ThemeProviderFactory from '../ThemeProviderFactory'
+import { THEME_CHANNEL } from '../themeChannel'
 
 const withTheme = withThemeFactory(Component, createElement, {
-  theme: PropTypes.object,
+  [THEME_CHANNEL]: PropTypes.object,
 })
 
 const ThemeProvider = ThemeProviderFactory(
@@ -19,10 +20,10 @@ const ThemeProvider = ThemeProviderFactory(
       overwrite: PropTypes.bool,
     },
     childContextTypes: {
-      theme: PropTypes.object,
+      [THEME_CHANNEL]: PropTypes.object,
     },
     contextTypes: {
-      theme: PropTypes.object,
+      [THEME_CHANNEL]: PropTypes.object,
     },
     defaultProps: {
       overwrite: false,

--- a/packages/fela-bindings/src/__tests__/__snapshots__/connectFactory-test.js.snap
+++ b/packages/fela-bindings/src/__tests__/__snapshots__/connectFactory-test.js.snap
@@ -15,8 +15,8 @@ Array [
     color="red"
 >
     <ConnectedFelaComponent
+        _felaTheme={Object {}}
         color="red"
-        theme={Object {}}
     >
         <Component
             color="red"
@@ -58,8 +58,8 @@ Array [
     color="red"
 >
     <ConnectedFelaComponent
+        _felaTheme={Object {}}
         color="red"
-        theme={Object {}}
     >
         <Component
             color="red"
@@ -99,8 +99,8 @@ Array [
     color="red"
 >
     <ConnectedFelaComponent
+        _felaTheme={Object {}}
         color="red"
-        theme={Object {}}
     >
         <Component
             color="red"

--- a/packages/fela-bindings/src/__tests__/__snapshots__/createComponentFactory-test.js.snap
+++ b/packages/fela-bindings/src/__tests__/__snapshots__/createComponentFactory-test.js.snap
@@ -13,7 +13,7 @@ Array [
 </style>",
   <rule>
     <rule
-        theme={
+        _felaTheme={
             Object {
                 "header": Object {
                   "color": "black",
@@ -37,9 +37,9 @@ Array [
     onClick={[Function]}
 >
     <FelaComponent
+        _felaTheme={Object {}}
         color="red"
         onClick={[Function]}
-        theme={Object {}}
     >
         <FelaComponent
             _felaRule={[Function]}
@@ -50,10 +50,10 @@ Array [
                     "onClick",
                   ]
             }
-            theme={Object {}}
         >
             <FelaComponent
                 _felaRule={[Function]}
+                _felaTheme={Object {}}
                 color="red"
                 onClick={[Function]}
                 passThrough={
@@ -61,7 +61,6 @@ Array [
                         "onClick",
                       ]
                 }
-                theme={Object {}}
             >
                 <div
                     className=""
@@ -92,17 +91,16 @@ Array [
 </style>",
   <anotherRule>
     <anotherRule
-        theme={Object {}}
+        _felaTheme={Object {}}
     >
         <rule
             _felaRule={[Function]}
             passThrough={Array []}
-            theme={Object {}}
         >
             <rule
                 _felaRule={[Function]}
+                _felaTheme={Object {}}
                 passThrough={Array []}
-                theme={Object {}}
             >
                 <div
                     className="a b c"
@@ -134,9 +132,9 @@ Array [
     extend={[Function]}
 >
     <rule
+        _felaTheme={Object {}}
         bgColor="red"
         extend={[Function]}
-        theme={Object {}}
     >
         <div
             className="a b c"
@@ -170,13 +168,13 @@ Array [
     }
 >
     <rule
+        _felaTheme={Object {}}
         extend={
             Object {
                 "backgroundColor": "red",
                 "fontSize": "14px",
               }
         }
-        theme={Object {}}
     >
         <div
             className="a b c"
@@ -201,8 +199,8 @@ Array [
     color="red"
 >
     <rule
+        _felaTheme={Object {}}
         color="red"
-        theme={Object {}}
     >
         <Comp
             className="a b"
@@ -236,10 +234,10 @@ Array [
     onHover={true}
 >
     <rule
+        _felaTheme={Object {}}
         color={true}
         onClick={false}
         onHover={true}
-        theme={Object {}}
     >
         <div
             className="a b"
@@ -266,9 +264,9 @@ Array [
     data-foo={true}
 >
     <rule
+        _felaTheme={Object {}}
         color="black"
         data-foo={true}
-        theme={Object {}}
     >
         <div
             className="a b"
@@ -294,8 +292,8 @@ Array [
     as="button"
 >
     <Button
+        _felaTheme={Object {}}
         as="button"
-        theme={Object {}}
     >
         <button
             className="a b"
@@ -317,9 +315,9 @@ Array [
     onClick={false}
 >
     <rule
+        _felaTheme={Object {}}
         data-foo={true}
         onClick={false}
-        theme={Object {}}
     >
         <div
             className="a"
@@ -351,13 +349,13 @@ Array [
     }
 >
     <rule
+        _felaTheme={Object {}}
         color="blue"
         testProp={
             Object {
                 "tabIndex": "-1",
               }
         }
-        theme={Object {}}
     >
         <UnderlyingComp
             className="a b"
@@ -377,8 +375,8 @@ Array [
     color="blue"
 >
     <rule
+        _felaTheme={Object {}}
         color="blue"
-        theme={Object {}}
     >
         <UnderlyingComp
             className="a b"
@@ -412,9 +410,9 @@ Array [
     color="blue"
 >
     <rule
+        _felaTheme={Object {}}
         as="i"
         color="blue"
-        theme={Object {}}
     >
         <i
             className="a b"
@@ -425,8 +423,8 @@ Array [
     color="blue"
 >
     <rule
+        _felaTheme={Object {}}
         color="blue"
-        theme={Object {}}
     >
         <div
             className="c b"
@@ -456,23 +454,22 @@ Array [
     color="green"
 >
     <anotherRule
+        _felaTheme={Object {}}
         as="i"
         color="green"
-        theme={Object {}}
     >
         <rule
             _felaRule={[Function]}
             as="i"
             color="green"
             passThrough={Array []}
-            theme={Object {}}
         >
             <rule
                 _felaRule={[Function]}
+                _felaTheme={Object {}}
                 as="i"
                 color="green"
                 passThrough={Array []}
-                theme={Object {}}
             >
                 <i
                     className="a b c"
@@ -499,8 +496,8 @@ Array [
     color="black"
 >
     <rule
+        _felaTheme={Object {}}
         color="black"
-        theme={Object {}}
     >
         <div
             className="a b"
@@ -519,7 +516,7 @@ Array [
 </style>",
   <Button>
     <Button
-        theme={Object {}}
+        _felaTheme={Object {}}
     >
         <div
             className="Fela-Button_div__abrv9k"
@@ -538,7 +535,7 @@ Array [
 </style>",
   <Button>
     <Button
-        theme={Object {}}
+        _felaTheme={Object {}}
     >
         <div
             className="Button_div__abrv9k"
@@ -561,7 +558,7 @@ Array [
 </style>",
   <rule>
     <rule
-        theme={
+        _felaTheme={
             Object {
                 "color": "red",
               }
@@ -588,7 +585,7 @@ Array [
 </style>",
   <rule>
     <rule
-        theme={
+        _felaTheme={
             Object {
                 "header": Object {
                   "color": "black",
@@ -612,9 +609,9 @@ Array [
     onClick={[Function]}
 >
     <FelaComponent
+        _felaTheme={Object {}}
         color="red"
         onClick={[Function]}
-        theme={Object {}}
     >
         <FelaComponent
             _felaRule={[Function]}
@@ -627,10 +624,10 @@ Array [
                     "color",
                   ]
             }
-            theme={Object {}}
         >
             <FelaComponent
                 _felaRule={[Function]}
+                _felaTheme={Object {}}
                 color="red"
                 onClick={[Function]}
                 passThrough={
@@ -640,7 +637,6 @@ Array [
                         "color",
                       ]
                 }
-                theme={Object {}}
             >
                 <div
                     className=""
@@ -671,17 +667,16 @@ Array [
 </style>",
   <anotherRule>
     <anotherRule
-        theme={Object {}}
+        _felaTheme={Object {}}
     >
         <rule
             _felaRule={[Function]}
             passThrough={Array []}
-            theme={Object {}}
         >
             <rule
                 _felaRule={[Function]}
+                _felaTheme={Object {}}
                 passThrough={Array []}
-                theme={Object {}}
             >
                 <div
                     className="a b c"
@@ -710,10 +705,10 @@ Array [
     onClick={false}
 >
     <rule
+        _felaTheme={Object {}}
         color={true}
         data-foo={true}
         onClick={false}
-        theme={Object {}}
     >
         <div
             className="a b"
@@ -741,9 +736,9 @@ Array [
     data-foo={true}
 >
     <rule
+        _felaTheme={Object {}}
         color="black"
         data-foo={true}
-        theme={Object {}}
     >
         <div
             className="a b"
@@ -770,8 +765,8 @@ Array [
     as="button"
 >
     <Button
+        _felaTheme={Object {}}
         as="button"
-        theme={Object {}}
     >
         <button
             className="a b"
@@ -793,9 +788,9 @@ Array [
     onClick={false}
 >
     <rule
+        _felaTheme={Object {}}
         data-foo={true}
         onClick={false}
-        theme={Object {}}
     >
         <div
             className="a"
@@ -824,10 +819,10 @@ Array [
     onClick={false}
 >
     <rule
+        _felaTheme={Object {}}
         color={true}
         data-foo={true}
         onClick={false}
-        theme={Object {}}
     >
         <div
             className="a b"
@@ -855,8 +850,8 @@ Array [
     color="black"
 >
     <rule
+        _felaTheme={Object {}}
         color="black"
-        theme={Object {}}
     >
         <div
             className="a b"
@@ -875,7 +870,7 @@ Array [
 </style>",
   <Button>
     <Button
-        theme={Object {}}
+        _felaTheme={Object {}}
     >
         <div
             className="Fela-Button_div__abrv9k"
@@ -894,7 +889,7 @@ Array [
 </style>",
   <Button>
     <Button
-        theme={Object {}}
+        _felaTheme={Object {}}
     >
         <div
             className="Button_div__abrv9k"
@@ -917,7 +912,7 @@ Array [
 </style>",
   <rule>
     <rule
-        theme={
+        _felaTheme={
             Object {
                 "color": "black",
               }
@@ -947,9 +942,9 @@ Array [
     innerRef={[Function]}
 >
     <rule
+        _felaTheme={Object {}}
         color="black"
         innerRef={[Function]}
-        theme={Object {}}
     >
         <div
             className="a b"

--- a/packages/fela-bindings/src/__tests__/connectFactory-test.js
+++ b/packages/fela-bindings/src/__tests__/connectFactory-test.js
@@ -9,9 +9,10 @@ import { createRenderer } from 'fela'
 
 import connectFactory from '../connectFactory'
 import withThemeFactory from '../withThemeFactory'
+import { THEME_CHANNEL } from '../themeChannel'
 
 const withTheme = withThemeFactory(Component, createElement, {
-  theme: PropTypes.object,
+  [THEME_CHANNEL]: PropTypes.object,
 })
 
 const connect = connectFactory(Component, createElement, withTheme, {
@@ -119,7 +120,7 @@ describe('Connect Factory for bindings', () => {
 
     expect(rules).toHaveBeenCalledWith({
       color: 'red',
-      theme: {},
+      _felaTheme: {},
     })
     expect(rules).toHaveBeenCalledTimes(1)
     expect([

--- a/packages/fela-bindings/src/__tests__/createComponentFactory-test.js
+++ b/packages/fela-bindings/src/__tests__/createComponentFactory-test.js
@@ -11,9 +11,10 @@ import monolithic from 'fela-monolithic'
 import createComponentFactory from '../createComponentFactory'
 import withThemeFactory from '../withThemeFactory'
 import createTheme from '../createTheme'
+import { THEME_CHANNEL } from '../themeChannel'
 
 const withTheme = withThemeFactory(BaseComponent, createElement, {
-  theme: PropTypes.object,
+  [THEME_CHANNEL]: PropTypes.object,
 })
 
 const createComponent = createComponentFactory(createElement, withTheme, {
@@ -114,7 +115,7 @@ describe('Creating Components from Fela rules', () => {
     const wrapper = mount(<Component />, {
       context: {
         renderer,
-        theme,
+        [THEME_CHANNEL]: theme,
       },
     })
 
@@ -141,7 +142,7 @@ describe('Creating Components from Fela rules', () => {
     const wrapper = mount(<Component />, {
       context: {
         renderer,
-        theme,
+        [THEME_CHANNEL]: theme,
       },
     })
 
@@ -549,7 +550,7 @@ describe('Creating Components with a Proxy for props from Fela rules', () => {
     const wrapper = mount(<Component />, {
       context: {
         renderer,
-        theme,
+        [THEME_CHANNEL]: theme,
       },
     })
 
@@ -575,7 +576,7 @@ describe('Creating Components with a Proxy for props from Fela rules', () => {
     const wrapper = mount(<Component />, {
       context: {
         renderer,
-        theme,
+        [THEME_CHANNEL]: theme,
       },
     })
 

--- a/packages/fela-bindings/src/connectFactory.js
+++ b/packages/fela-bindings/src/connectFactory.js
@@ -17,6 +17,7 @@ export default function connectFactory(
 
         render() {
           const { renderer } = this.context
+          const { _felaTheme, ...otherProps } = this.props
 
           const preparedRules =
             typeof rules === 'function' ? rules(this.props) : rules
@@ -26,15 +27,18 @@ export default function connectFactory(
             (styleMap, rule, name) => {
               const preparedRule =
                 typeof rule !== 'function' ? () => rule : rule
-              styleMap[name] = renderer.renderRule(preparedRule, this.props)
+              styleMap[name] = renderer.renderRule(preparedRule, {
+                ...otherProps,
+                theme: _felaTheme,
+              })
+
               return styleMap
             },
             {}
           )
 
-          const { theme, ...propsWithoutTheme } = this.props
           return createElement(component, {
-            ...propsWithoutTheme,
+            ...otherProps,
             styles,
           })
         }
@@ -44,7 +48,7 @@ export default function connectFactory(
         EnhancedComponent.contextTypes = contextTypes
       }
 
-      const themedComponent = withTheme(EnhancedComponent)
+      const themedComponent = withTheme(EnhancedComponent, '_felaTheme')
       return hoistStatics(themedComponent, component)
     }
   }

--- a/packages/fela-bindings/src/createComponentFactory.js
+++ b/packages/fela-bindings/src/createComponentFactory.js
@@ -24,7 +24,7 @@ export default function createComponentFactory(
     const FelaComponent = (
       {
         children,
-        theme,
+        _felaTheme,
         _felaRule,
         extend,
         innerRef,
@@ -43,7 +43,7 @@ export default function createComponentFactory(
         )
       }
 
-      const usedProps = withProxy ? extractUsedProps(rule, theme) : []
+      const usedProps = withProxy ? extractUsedProps(rule, _felaTheme) : []
 
       const rules = [rule]
       if (_felaRule) {
@@ -73,7 +73,7 @@ export default function createComponentFactory(
 
       const ruleProps = {
         ...otherProps,
-        theme,
+        theme: _felaTheme,
         as,
         id,
       }
@@ -89,7 +89,9 @@ export default function createComponentFactory(
             innerRef,
             style,
             className,
-            ...ruleProps,
+            as,
+            id,
+            ...otherProps,
           },
           children
         )
@@ -134,7 +136,7 @@ export default function createComponentFactory(
     FelaComponent.displayName = displayName
     FelaComponent._isFelaComponent = true
 
-    const themedComponent = withTheme(FelaComponent)
+    const themedComponent = withTheme(FelaComponent, '_felaTheme')
     return hoistStatics(themedComponent, type)
   }
 }

--- a/packages/fela-bindings/src/index.js
+++ b/packages/fela-bindings/src/index.js
@@ -4,6 +4,7 @@ import ProviderFactory from './ProviderFactory'
 import ThemeProviderFactory from './ThemeProviderFactory'
 import withThemeFactory from './withThemeFactory'
 import createTheme from './createTheme'
+import { THEME_CHANNEL } from './themeChannel'
 
 export {
   connectFactory,
@@ -12,4 +13,5 @@ export {
   ThemeProviderFactory,
   withThemeFactory,
   createTheme,
+  THEME_CHANNEL,
 }

--- a/packages/fela-bindings/src/themeChannel.js
+++ b/packages/fela-bindings/src/themeChannel.js
@@ -1,0 +1,1 @@
+export const THEME_CHANNEL = '_FELA_THEME_'

--- a/packages/fela-bindings/src/withThemeFactory.js
+++ b/packages/fela-bindings/src/withThemeFactory.js
@@ -1,12 +1,16 @@
 /* @flow */
 import hoistStatics from './hoistStatics'
+import { THEME_CHANNEL } from './themeChannel'
 
 export default function withThemeFactory(
   BaseComponent: any,
   createElement: Function,
   contextTypes?: Object
 ): Function {
-  return function withTheme(component: Object): Object {
+  return function withTheme(
+    component: Object,
+    propName?: string = 'theme'
+  ): Object {
     class WithTheme extends BaseComponent {
       state: {
         theme: Object,
@@ -18,13 +22,13 @@ export default function withThemeFactory(
         super(props, context)
 
         this.state = {
-          theme: context.theme ? context.theme.get() : {},
+          theme: context[THEME_CHANNEL] ? context[THEME_CHANNEL].get() : {},
         }
       }
 
       componentWillMount() {
-        if (this.context.theme) {
-          this.unsubscribe = this.context.theme.subscribe(properties =>
+        if (this.context[THEME_CHANNEL]) {
+          this.unsubscribe = this.context[THEME_CHANNEL].subscribe(properties =>
             this.setState({
               theme: properties,
             })
@@ -51,7 +55,7 @@ export default function withThemeFactory(
 
         return createElement(component, {
           ...passProps,
-          theme: this.state.theme,
+          [propName]: this.state.theme,
         })
       }
     }

--- a/packages/fela/README.md
+++ b/packages/fela/README.md
@@ -46,9 +46,9 @@ You may alternatively use `npm i --save fela`.
 * Local namespace
 
 ## The Gist
-Fela's core principle is to consider **style as a function of state**.<br>
+Fela's core principle is to consider [style as a function of state](https://medium.com/@rofrischmann/styles-as-functions-of-state-1885627a63f7#.6k6i4kdch).<br>
 The whole API and all plugins and bindings are built on that idea.<br>
-It is reactive and auto-updates onces registered to the DOM.<br>
+It is reactive and auto-updates once registered to the DOM.<br>
 
 The following example illustrates the key parts of Fela though it only shows the very basics.
 
@@ -64,7 +64,6 @@ const rule = state => ({
   background: state.primary ? 'green' : 'blue',
   fontSize: '18pt',
   borderRadius: 5,
-
   // deeply nest media queries and pseudo classes
   ':hover': {
     background: state.primary ? 'chartreuse' : 'dodgerblue',
@@ -104,7 +103,18 @@ If you ever used [styled-components](https://www.styled-components.com), this wi
 import { createComponent, Provider } from 'react-fela'
 import { render } from 'react-dom'
 
-// using the above defined rule and fela renderer
+const rule = state => ({
+  textAlign: 'center',
+  padding: '5px 10px',
+  background: state.primary ? 'green' : 'blue',
+  fontSize: '18pt',
+  borderRadius: 5,
+  ':hover': {
+    background: state.primary ? 'chartreuse' : 'dodgerblue',
+    boxShadow: '0 0 2px rgb(70, 70, 70)'
+  }
+})
+
 const Button = createComponent(rule, 'button')
 
 render(
@@ -135,6 +145,7 @@ render(
 * [Usage Guides](http://fela.js.org/docs/UsageGuides.html)
 * [Recipes](http://fela.js.org/docs/Recipes.html)
 * [API Reference](http://fela.js.org/docs/API.html)
+* [Migration Guide](http://fela.js.org/docs/MigrationGuide.html)
 * [Troubleshooting](http://fela.js.org/docs/Troubleshooting.html)
 * [FAQ](http://fela.js.org/docs/FAQ.html)
 * [Feedback](http://fela.js.org/docs/Feedback.html)
@@ -144,7 +155,7 @@ render(
 If you are coming from CSS and want to learn JavaScript Styling with Fela, there is a full-feature [fela-workshop](https://github.com/tajo/fela-workshop) which demonstrates typical Fela use cases. It teaches all important parts, step by step with simple examples. If you already know other CSS in JS solutions and are just switching to Fela, you might not need to do the whole workshop, but it still provides useful information to get started quickly.
 
 ## Posts & Talks
-* [**CSS in JS: The Good & Bad Parts**](https://youtu.be/X9iqnovPGyY?t=1h41m47s) ([Slides](https://speakerdeck.com/rofrischmann/css-in-js-the-good-and-bad-parts))<br> - *by [Robin Frischmann](https://twitter.com/rofrischmann)*
+* [**CSS in JS: The Good & Bad Parts**](https://www.youtube.com/watch?v=95M-2YzyTno) ([Slides](https://speakerdeck.com/rofrischmann/css-in-js-the-good-and-bad-parts))<br> - *by [Robin Frischmann](https://twitter.com/rofrischmann)*
 * [**Style as a Function of State**](https://medium.com/@rofrischmann/styles-as-functions-of-state-1885627a63f7#.6k6i4kdch)<br> - *by [Robin Frischmann](https://twitter.com/rofrischmann)*
 * [**CSS in JS: The Argument Refined**](https://medium.com/@steida/css-in-js-the-argument-refined-471c7eb83955#.3otvkubq4)<br> - *by [Daniel Steigerwald](https://twitter.com/steida)*
 * [**What is Fela?**](https://davidsinclair.io/thoughts/what-is-fela)<br> - *by [David Sinclair](https://davidsinclair.io)*

--- a/packages/preact-fela/src/createComponentWithProxy.js
+++ b/packages/preact-fela/src/createComponentWithProxy.js
@@ -4,4 +4,4 @@ import { createComponentFactory } from 'fela-bindings'
 
 import withTheme from './withTheme'
 
-export default createComponentFactory(h, withTheme, null, true)
+export default createComponentFactory(h, withTheme, undefined, true)

--- a/packages/react-fela/docs/withTheme.md
+++ b/packages/react-fela/docs/withTheme.md
@@ -1,4 +1,4 @@
-# `withTheme(component)`
+# `withTheme(component, [propName])`
 
 Passes the local theme to the `component` via props. Therefore, any enhanced component must, at some point, be wrapped with a [`<ThemeProvider>`](ThemeProvider.md) component.
 
@@ -6,7 +6,8 @@ It will automatically be updated if the theme changes, even if the parent implem
 
 
 ## Arguments
-1. ([Component](https://facebook.github.io/react/docs/top-level-api.html#react.component)): A valid React component.
+1. `component` (*[Component](https://facebook.github.io/react/docs/top-level-api.html#react.component)*): A valid React component.
+2. `propName` (*string?*): An alternative name that is used to pass the theme. Defaults to `theme`.
 
 ## Example
 ```javascript

--- a/packages/react-fela/src/ThemeProvider.js
+++ b/packages/react-fela/src/ThemeProvider.js
@@ -1,6 +1,6 @@
 /* @flow */
 import { Component, Children } from 'react'
-import { ThemeProviderFactory } from 'fela-bindings'
+import { ThemeProviderFactory, THEME_CHANNEL } from 'fela-bindings'
 import PropTypes from 'prop-types'
 
 export default ThemeProviderFactory(
@@ -12,10 +12,10 @@ export default ThemeProviderFactory(
       overwrite: PropTypes.bool,
     },
     childContextTypes: {
-      theme: PropTypes.object,
+      [THEME_CHANNEL]: PropTypes.object,
     },
     contextTypes: {
-      theme: PropTypes.object,
+      [THEME_CHANNEL]: PropTypes.object,
     },
     defaultProps: {
       overwrite: false,

--- a/packages/react-fela/src/connect.js
+++ b/packages/react-fela/src/connect.js
@@ -1,11 +1,11 @@
 /* @flow */
 import { Component, createElement } from 'react'
 import PropTypes from 'prop-types'
-import { connectFactory } from 'fela-bindings'
+import { connectFactory, THEME_CHANNEL } from 'fela-bindings'
 
 import withTheme from './withTheme'
 
 export default connectFactory(Component, createElement, withTheme, {
   renderer: PropTypes.object,
-  theme: PropTypes.object,
+  [THEME_CHANNEL]: PropTypes.object,
 })

--- a/packages/react-fela/src/createComponent.js
+++ b/packages/react-fela/src/createComponent.js
@@ -1,11 +1,11 @@
 /* @flow */
 import { createElement } from 'react'
 import PropTypes from 'prop-types'
-import { createComponentFactory } from 'fela-bindings'
+import { createComponentFactory, THEME_CHANNEL } from 'fela-bindings'
 
 import withTheme from './withTheme'
 
 export default createComponentFactory(createElement, withTheme, {
   renderer: PropTypes.object,
-  theme: PropTypes.object,
+  [THEME_CHANNEL]: PropTypes.object,
 })

--- a/packages/react-fela/src/createComponentWithProxy.js
+++ b/packages/react-fela/src/createComponentWithProxy.js
@@ -1,7 +1,7 @@
 /* @flow */
 import { createElement } from 'react'
 import PropTypes from 'prop-types'
-import { createComponentFactory } from 'fela-bindings'
+import { createComponentFactory, THEME_CHANNEL } from 'fela-bindings'
 
 import withTheme from './withTheme'
 
@@ -10,7 +10,7 @@ export default createComponentFactory(
   withTheme,
   {
     renderer: PropTypes.object,
-    theme: PropTypes.object,
+    [THEME_CHANNEL]: PropTypes.object,
   },
   true
 )

--- a/packages/react-fela/src/withTheme.js
+++ b/packages/react-fela/src/withTheme.js
@@ -1,8 +1,8 @@
 /* @flow */
 import { Component, createElement } from 'react'
 import PropTypes from 'prop-types'
-import { withThemeFactory } from 'fela-bindings'
+import { withThemeFactory, THEME_CHANNEL } from 'fela-bindings'
 
 export default withThemeFactory(Component, createElement, {
-  theme: PropTypes.object,
+  [THEME_CHANNEL]: PropTypes.object,
 })


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guide-lines at the bottom.
------------------------------------------->

## Description
With this PR, theming won't be done using the `theme` context key anymore, but rather defaults to `_FELA_THEME_` now. `withTheme` now also accepts an optional `propName` argument to rename the prop that is passed to the wrapped component. Within `createComponent` and `connect` we're using `_felaTheme` to avoid conflicts with other `theme` props.


## Versioning
<!------------------------------------------
  Please add all updated packages and propose new versions following the semantic versioning guidelines
------------------------------------------->


#### Major

#### Minor
* fela-bindings

#### Patch
* react-fela
* inferno-fela
* preact-fela

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

