### PR TITLE
Feature/bug animation important

### DIFF
--- a/packages/fela-plugin-important/README.md
+++ b/packages/fela-plugin-important/README.md
@@ -2,7 +2,7 @@
 
 <img alt="npm version" src="https://badge.fury.io/js/fela-plugin-important.svg"> <img alt="npm downloads" src="https://img.shields.io/npm/dm/fela-plugin-important.svg">
 
-Adds `!important` to every declaration value. This helps to force specificity over third-party libraries.
+Adds `!important` to every declaration value except animations item and keyframes. This helps to force specificity over third-party libraries. Animation items and keyframes with `!important` disrupt functionality of animations. [More about.](https://developer.mozilla.org/en-US/docs/Web/CSS/%40keyframes#!important_in_a_keyframe) 
 
 ## Installation
 ```sh

--- a/packages/fela-plugin-important/src/__tests__/important-test.js
+++ b/packages/fela-plugin-important/src/__tests__/important-test.js
@@ -1,15 +1,17 @@
 import important from '../index'
 
 describe('Important plugin', () => {
-  it('should add !important to every number and string', () => {
+  it('should add !important to every number and string which are not animated', () => {
     const style = {
       color: 'blue',
       fontSize: 15,
+      animationName: 'k3',
     }
 
     expect(important()(style)).toEqual({
-      color: 'blue!important',
-      fontSize: '15!important',
+      color: 'blue',
+      fontSize: 15,
+      animationName: 'k3',
     })
   })
 

--- a/packages/fela-plugin-important/src/index.js
+++ b/packages/fela-plugin-important/src/index.js
@@ -15,20 +15,42 @@ function addImportantToValue(value: any): any {
   return value
 }
 
-function addImportant(style: Object): Object {
-  for (const property in style) {
-    const value = style[property]
-
-    if (isPlainObject(value)) {
-      style[property] = addImportant(value)
-    } else if (Array.isArray(value)) {
-      style[property] = value.map(addImportantToValue)
-    } else {
-      style[property] = addImportantToValue(value)
+/* Remove items with features of animation or keyframes from array 
+*  where '!imporatant' should be added 
+* 
+*  @return true if item is animation 
+*/ 
+function isAnimation(style: Object): Boolean {
+  const styleNames = Object.getOwnPropertyNames(style)
+  const resctrictions = [ 'from', 'to', '%', 'animation']
+  let isAnimationItem = false
+ 
+  for(const property in styleNames) {
+    const value = styleNames[property]
+    
+    for(const res in resctrictions) {
+      isAnimationItem = value.includes(resctrictions[res]) || property.includes(resctrictions[res])
+    }
+  } 
+  return isAnimationItem
+} 
+ 
+function addImportant(style: Object): Object { 
+  if(!isAnimation(style)) { 
+    for (const property in style) { 
+      const value = style[property] 
+ 
+      if (isPlainObject(value)) { 
+        style[property] = addImportant(value) 
+      } else if (Array.isArray(value)) { 
+        style[property] = value.map(addImportantToValue) 
+      } else { 
+        style[property] = addImportantToValue(value) 
+      }
     }
   }
 
   return style
-}
+} 
 
 export default () => addImportant


### PR DESCRIPTION
## Description
Adds `!important` to every declaration value except animated items (not by `transition`) and keyframes. Animation items and keyframes with `!important` disrupt functionality of animations. [More about.](https://developer.mozilla.org/en-US/docs/Web/CSS/%40keyframes#!important_in_a_keyframe) 

For every items which includes any property of `animation*:` should be set **manually**, because not possible to catch, what property will be changed by `keyframes`. 
Every `keyframes` are catched according to key property `to`, `from` and if they contains `%`.
