### PR TITLE
Doc fix: 'named-media-query' should be 'named-keys'

### DIFF
--- a/docs/advanced/Plugins.md
+++ b/docs/advanced/Plugins.md
@@ -35,7 +35,7 @@ Plugins are executed in the exact same order as provided. The output of the firs
 2. [fela-plugin-custom-property](https://github.com/rofrischmann/fela/tree/master/packages/fela-plugin-custom-property)
 3. [fela-plugin-embedded](https://github.com/rofrischmann/fela/tree/master/packages/fela-plugin-embedded)
 4. [fela-plugin-friendly-pseudo-class](https://github.com/rofrischmann/fela/tree/master/packages/fela-plugin-friendly-pseudo-class)
-5. [fela-plugin-named-media-query](https://github.com/rofrischmann/fela/tree/master/packages/fela-plugin-named-media-query)
+5. [fela-plugin-named-keys](https://github.com/rofrischmann/fela/tree/master/packages/fela-plugin-named-keys)
 6. [fela-plugin-lvha](https://github.com/rofrischmann/fela/tree/master/packages/fela-plugin-lvha)
 7. [fela-plugin-placeholder-prefixer](https://github.com/rofrischmann/fela/tree/master/packages/fela-plugin-placeholder-prefixer)
 8. [fela-plugin-prefixer](https://github.com/rofrischmann/fela/tree/master/packages/fela-plugin-prefixer)


### PR DESCRIPTION
`fela-plugin-named-media-query` was renamed to `fela-plugin-named-keys` in commit 1b2257d053568745f58fa0e8889f9f0120e2795e