### PR TITLE
Babel Plugin Hashing Mechanism

### DIFF
--- a/packages/babel-plugin-fela/src/__tests__/__snapshots__/createPlugin-test.js.snap
+++ b/packages/babel-plugin-fela/src/__tests__/__snapshots__/createPlugin-test.js.snap
@@ -447,8 +447,8 @@ Array [
   "import { createComponent } from 'react-fela';
 
 const rule = ({ fontSize, padding }, renderer) => {
-  if (!renderer.cache.1258790278) {
-    renderer.cache.1258790278= {
+  if (!renderer.cache.ktg8sm) {
+    renderer.cache.ktg8sm = {
       type: 'PRERENDERING',
       className: renderer.renderRule(() => ({
         color: 'red',
@@ -464,7 +464,7 @@ const rule = ({ fontSize, padding }, renderer) => {
   }
 
   return {
-    _className: renderer.cache.1258790278.className,
+    _className: renderer.cache.ktg8sm.className,
 
     fontSize, '@media (min-height: 300px)': { ':hover': { paddingLeft: padding
       }
@@ -482,8 +482,8 @@ Array [
   "import { createComponent } from 'react-fela';
 
 export default createComponent(({ fontSize, padding }, renderer) => {
-  if (!renderer.cache.3434345636) {
-    renderer.cache.3434345636= {
+  if (!renderer.cache.1kspy1w) {
+    renderer.cache.1kspy1w = {
       type: 'PRERENDERING',
       className: renderer.renderRule(() => ({
         color: 'red',
@@ -499,7 +499,7 @@ export default createComponent(({ fontSize, padding }, renderer) => {
   }
 
   return {
-    _className: renderer.cache.3434345636.className,
+    _className: renderer.cache.1kspy1w.className,
 
     fontSize, '@media (min-height: 300px)': { ':hover': { paddingLeft: padding
       }
@@ -515,8 +515,8 @@ Array [
   "import { createComponent } from 'react-fela';
 
 const rule = (_, renderer) => {
-  if (!renderer.cache.3904749910) {
-    renderer.cache.3904749910= {
+  if (!renderer.cache.1skscba) {
+    renderer.cache.1skscba = {
       type: 'PRERENDERING',
       className: renderer.renderRule(() => ({
         color: 'red',
@@ -532,7 +532,7 @@ const rule = (_, renderer) => {
   }
 
   return {
-    _className: renderer.cache.3904749910.className
+    _className: renderer.cache.1skscba.className
   };
 };
 
@@ -546,8 +546,8 @@ Array [
   "import { createComponent } from 'react-fela';
 
 function rule({ fontSize, padding }, renderer) {
-  if (!renderer.cache.1994830291) {
-    renderer.cache.1994830291= {
+  if (!renderer.cache.wzo4wj) {
+    renderer.cache.wzo4wj = {
       type: 'PRERENDERING',
       className: renderer.renderRule(() => ({
         color: 'red',
@@ -563,7 +563,7 @@ function rule({ fontSize, padding }, renderer) {
   }
 
   return {
-    _className: renderer.cache.1994830291.className,
+    _className: renderer.cache.wzo4wj.className,
 
     fontSize, '@media (min-height: 300px)': { ':hover': { paddingLeft: padding
       }
@@ -581,8 +581,8 @@ Array [
   "import { createComponent } from 'react-fela';
 
 const rule = function ({ fontSize, padding }, renderer) {
-  if (!renderer.cache.1173747665) {
-    renderer.cache.1173747665= {
+  if (!renderer.cache.jethht) {
+    renderer.cache.jethht = {
       type: 'PRERENDERING',
       className: renderer.renderRule(() => ({
         color: 'red',
@@ -598,7 +598,7 @@ const rule = function ({ fontSize, padding }, renderer) {
   }
 
   return {
-    _className: renderer.cache.1173747665.className,
+    _className: renderer.cache.jethht.className,
 
     fontSize, '@media (min-height: 300px)': { ':hover': { paddingLeft: padding
       }
@@ -640,8 +640,8 @@ Array [
   "import { createComponent } from 'react-fela';
 
 const rule = ({ fontSize, padding }, renderer) => {
-  if (!renderer.cache.2598482558) {
-    renderer.cache.2598482558= {
+  if (!renderer.cache.16z2hz2) {
+    renderer.cache.16z2hz2 = {
       type: 'PRERENDERING',
       className: renderer.renderRule(() => ({
         _className: 'foo bar',
@@ -659,7 +659,7 @@ const rule = ({ fontSize, padding }, renderer) => {
   }
 
   return {
-    _className: renderer.cache.2598482558.className,
+    _className: renderer.cache.16z2hz2.className,
     fontSize, '@media (min-height: 300px)': { ':hover': { paddingLeft: padding
       }
     }
@@ -676,8 +676,8 @@ Array [
   "import { createComponent } from 'react-fela';
 
 const rule = ({ fontSize, padding }, felaRenderer) => {
-  if (!felaRenderer.cache.3309150636) {
-    felaRenderer.cache.3309150636= {
+  if (!felaRenderer.cache.1iq6kz0) {
+    felaRenderer.cache.1iq6kz0 = {
       type: 'PRERENDERING',
       className: felaRenderer.renderRule(() => ({
         color: 'red',
@@ -693,7 +693,7 @@ const rule = ({ fontSize, padding }, felaRenderer) => {
   }
 
   return {
-    _className: felaRenderer.cache.3309150636.className,
+    _className: felaRenderer.cache.1iq6kz0.className,
 
     fontSize, '@media (min-height: 300px)': { ':hover': { paddingLeft: padding
       }

--- a/packages/babel-plugin-fela/src/__tests__/__snapshots__/createPlugin-test.js.snap
+++ b/packages/babel-plugin-fela/src/__tests__/__snapshots__/createPlugin-test.js.snap
@@ -447,8 +447,8 @@ Array [
   "import { createComponent } from 'react-fela';
 
 const rule = ({ fontSize, padding }, renderer) => {
-  if (!renderer.cache.ktg8sm) {
-    renderer.cache.ktg8sm = {
+  if (!renderer.cache._ktg8sm) {
+    renderer.cache._ktg8sm = {
       type: 'PRERENDERING',
       className: renderer.renderRule(() => ({
         color: 'red',
@@ -464,7 +464,7 @@ const rule = ({ fontSize, padding }, renderer) => {
   }
 
   return {
-    _className: renderer.cache.ktg8sm.className,
+    _className: renderer.cache._ktg8sm.className,
 
     fontSize, '@media (min-height: 300px)': { ':hover': { paddingLeft: padding
       }
@@ -482,8 +482,8 @@ Array [
   "import { createComponent } from 'react-fela';
 
 export default createComponent(({ fontSize, padding }, renderer) => {
-  if (!renderer.cache.1kspy1w) {
-    renderer.cache.1kspy1w = {
+  if (!renderer.cache._1kspy1w) {
+    renderer.cache._1kspy1w = {
       type: 'PRERENDERING',
       className: renderer.renderRule(() => ({
         color: 'red',
@@ -499,7 +499,7 @@ export default createComponent(({ fontSize, padding }, renderer) => {
   }
 
   return {
-    _className: renderer.cache.1kspy1w.className,
+    _className: renderer.cache._1kspy1w.className,
 
     fontSize, '@media (min-height: 300px)': { ':hover': { paddingLeft: padding
       }
@@ -515,8 +515,8 @@ Array [
   "import { createComponent } from 'react-fela';
 
 const rule = (_, renderer) => {
-  if (!renderer.cache.1skscba) {
-    renderer.cache.1skscba = {
+  if (!renderer.cache._1skscba) {
+    renderer.cache._1skscba = {
       type: 'PRERENDERING',
       className: renderer.renderRule(() => ({
         color: 'red',
@@ -532,7 +532,7 @@ const rule = (_, renderer) => {
   }
 
   return {
-    _className: renderer.cache.1skscba.className
+    _className: renderer.cache._1skscba.className
   };
 };
 
@@ -546,8 +546,8 @@ Array [
   "import { createComponent } from 'react-fela';
 
 function rule({ fontSize, padding }, renderer) {
-  if (!renderer.cache.wzo4wj) {
-    renderer.cache.wzo4wj = {
+  if (!renderer.cache._wzo4wj) {
+    renderer.cache._wzo4wj = {
       type: 'PRERENDERING',
       className: renderer.renderRule(() => ({
         color: 'red',
@@ -563,7 +563,7 @@ function rule({ fontSize, padding }, renderer) {
   }
 
   return {
-    _className: renderer.cache.wzo4wj.className,
+    _className: renderer.cache._wzo4wj.className,
 
     fontSize, '@media (min-height: 300px)': { ':hover': { paddingLeft: padding
       }
@@ -581,8 +581,8 @@ Array [
   "import { createComponent } from 'react-fela';
 
 const rule = function ({ fontSize, padding }, renderer) {
-  if (!renderer.cache.jethht) {
-    renderer.cache.jethht = {
+  if (!renderer.cache._jethht) {
+    renderer.cache._jethht = {
       type: 'PRERENDERING',
       className: renderer.renderRule(() => ({
         color: 'red',
@@ -598,7 +598,7 @@ const rule = function ({ fontSize, padding }, renderer) {
   }
 
   return {
-    _className: renderer.cache.jethht.className,
+    _className: renderer.cache._jethht.className,
 
     fontSize, '@media (min-height: 300px)': { ':hover': { paddingLeft: padding
       }
@@ -640,8 +640,8 @@ Array [
   "import { createComponent } from 'react-fela';
 
 const rule = ({ fontSize, padding }, renderer) => {
-  if (!renderer.cache.16z2hz2) {
-    renderer.cache.16z2hz2 = {
+  if (!renderer.cache._16z2hz2) {
+    renderer.cache._16z2hz2 = {
       type: 'PRERENDERING',
       className: renderer.renderRule(() => ({
         _className: 'foo bar',
@@ -659,7 +659,7 @@ const rule = ({ fontSize, padding }, renderer) => {
   }
 
   return {
-    _className: renderer.cache.16z2hz2.className,
+    _className: renderer.cache._16z2hz2.className,
     fontSize, '@media (min-height: 300px)': { ':hover': { paddingLeft: padding
       }
     }
@@ -676,8 +676,8 @@ Array [
   "import { createComponent } from 'react-fela';
 
 const rule = ({ fontSize, padding }, felaRenderer) => {
-  if (!felaRenderer.cache.1iq6kz0) {
-    felaRenderer.cache.1iq6kz0 = {
+  if (!felaRenderer.cache._1iq6kz0) {
+    felaRenderer.cache._1iq6kz0 = {
       type: 'PRERENDERING',
       className: felaRenderer.renderRule(() => ({
         color: 'red',
@@ -693,7 +693,7 @@ const rule = ({ fontSize, padding }, felaRenderer) => {
   }
 
   return {
-    _className: felaRenderer.cache.1iq6kz0.className,
+    _className: felaRenderer.cache._1iq6kz0.className,
 
     fontSize, '@media (min-height: 300px)': { ':hover': { paddingLeft: padding
       }

--- a/packages/babel-plugin-fela/src/createPlugin.js
+++ b/packages/babel-plugin-fela/src/createPlugin.js
@@ -269,7 +269,9 @@ export default function createPlugin(userConfig = {}) {
 
                   // simple static style prerendering
                   if (staticStyle.length > 0) {
-                    id = generateHash(JSON.stringify(staticStyle)).toString(36)
+                    id =
+                      '_' +
+                      generateHash(JSON.stringify(staticStyle)).toString(36)
 
                     blockBody = t.blockStatement([
                       t.expressionStatement(

--- a/packages/babel-plugin-fela/src/createPlugin.js
+++ b/packages/babel-plugin-fela/src/createPlugin.js
@@ -269,7 +269,7 @@ export default function createPlugin(userConfig = {}) {
 
                   // simple static style prerendering
                   if (staticStyle.length > 0) {
-                    id = generateHash(JSON.stringify(staticStyle))
+                    id = generateHash(JSON.stringify(staticStyle)).toString(36)
 
                     blockBody = t.blockStatement([
                       t.expressionStatement(


### PR DESCRIPTION
closes #497

<!------------------------------------------
  Thanks for contributing!
  Please read the guide-lines at the bottom.
------------------------------------------->

## Description
Adds a simple `toString(36)` in order to turn the number hash into a short string starting with a letter. This way they can be accessed via direct object property accessors without yielding errors.

## Versioning
<!------------------------------------------
  Please add all updated packages and propose new versions following the semantic versioning guidelines
------------------------------------------->


#### Major

#### Minor

#### Patch
* babel-plugin-fela

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

