### PR TITLE
[fela-plugin-custom-property] Avoid deleting resolved custom properties

### DIFF
--- a/packages/fela-plugin-custom-property/src/__tests__/customProperty-test.js
+++ b/packages/fela-plugin-custom-property/src/__tests__/customProperty-test.js
@@ -56,4 +56,18 @@ describe('Custom property plugin', () => {
       },
     })
   })
+
+  it('should not remove resolved properties', () => {
+    const padding = value => ({ padding: value })
+
+    const style = {
+      padding: '1em',
+    }
+
+    expect(
+      customProperty({ padding })(style, 'RULE_TYPE', rendererMock)
+    ).toEqual({
+      padding: '1em',
+    })
+  })
 })

--- a/packages/fela-plugin-custom-property/src/index.js
+++ b/packages/fela-plugin-custom-property/src/index.js
@@ -16,8 +16,12 @@ function resolveCustomProperty(
     const value = style[property]
 
     if (properties.hasOwnProperty(property)) {
-      renderer._mergeStyle(style, properties[property](value))
-      delete style[property]
+      const resolved = properties[property](value)
+      renderer._mergeStyle(style, resolved)
+
+      if (!Object.keys(resolved).includes(property)) {
+        delete style[property]
+      }
     }
 
     if (isPlainObject(value)) {


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guide-lines at the bottom.
------------------------------------------->

## Description

This pull-request fixes a minor bug with the `fela-plugin-custom-property` plugin.

When naming a custom property after one of the CSS properties it eventually outputs, that very property gets deleted. It works well in the case of the `size` example as `size` should not be present in the output object, but when using this plugin a custom enhancer or validator, it doesn’t yield expected results.

## Example

```javascript
const shorthand = property => value => {
  console.warn(`The \`${property}\` should not be used because of lack of reusability of shorthand properties in Fela. Use the sub-properties instead.`)

  return { [property]: value }
}

export default createRenderer({
  plugins: [ customProperty({ padding: shorthand('padding') }) ],
  enhancers: [ … ]
})

```

## Versioning

`fela-plugin-custom-property` should be bumped to 6.0.4.

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

