### PR TITLE
added vue-fela-plugin to ecosystem

### DIFF
--- a/docs/introduction/Ecosystem.md
+++ b/docs/introduction/Ecosystem.md
@@ -20,6 +20,7 @@ Many plugins and enhancers are already included in the [main repository](https:/
 * [hyper-fela](https://github.com/ahdinosaur/hyper-fela) - HyperScript
 * [cycle-fela](https://github.com/wcastand/cycle-fela) - Cycle
 * [vue-fela](https://github.com/dustin-H/vue-fela) - Vue
+* [vue-fela-plugin](https://github.com/wagerfield/vue-fela) - Vue
 
 ### Plugins
 * [fela-plugin-bidi](https://github.com/rofrischmann/fela/tree/master/packages/fela-plugin-bidi) - Enable direction-independent style authoring


### PR DESCRIPTION
Firstly, thank you for Fela—it is nothing shy of awesome! I used React Look a few years ago [on this project](http://www.moon.co/), so it's great to see how this package has evolved.

Ok onto the PR...

I recently published [`vue-fela-plugin` to npm](https://github.com/wagerfield/vue-fela). The existing package `vue-fela` (which is currently referenced in the Fela Ecosystem docs) simply does not work—so I decided to write my own version.

Differences between `vue-fela` and `vue-fela-plugin`:

Feature | `vue-fela` | `vue-fela-plugin`
:-|:-:|:-:
Works as documented | throws errors | ✔︎
Uses the latest version of `fela` and `fela-dom` | v4.3.5 | ✔︎
Supports rule functions | only objects | ✔︎
Allows arbitrary `props` to be passed to rules | | ✔︎
Allows component instance state to be passed to rules | | ✔︎
Handles the rendering of styles on both client and server | | ✔︎
Follows prevailing Vue plugin design pattern | | ✔︎

In addition to the above, the version I published has been thoroughly documented and tested—_with 100% code coverage_.

I [opened an issue](https://github.com/dustin-H/vue-fela/issues/2) with the author of `vue-fela` to see if he was still maintaining the repo and package on npm since there hasn't been any commits since October. I have also requested the npm package name of `vue-fela`—but have not yet had a response.

Having tried to use `vue-fela` unsuccessfully (it just throws errors) it is my opinion that it should be removed from the Fela Ecosystem docs and replaced with mine. However, I didn't want to make this assertion in my PR, so have left the original in the docs and listed my version underneath.