### PR TITLE
don't resolve nested style objects if property was removed

### DIFF
--- a/packages/fela-plugin-custom-property/src/__tests__/customProperty-test.js
+++ b/packages/fela-plugin-custom-property/src/__tests__/customProperty-test.js
@@ -70,4 +70,21 @@ describe('Custom property plugin', () => {
       padding: '1em',
     })
   })
+
+  it('should not resolve nested style objects if property was removed', () => {
+    expect(
+      customProperty({
+        padding: ({ t, l, b, r }) => {
+          const obj = {}
+
+          if (t != null) obj.paddingTop = t
+          if (l != null) obj.paddingLeft = l
+          if (b != null) obj.paddingBottom = b
+          if (r != null) obj.paddingRight = r
+
+          return obj
+        }
+      })({ padding: { l: '1px' } }, 'RULE_TYPE', rendererMock)
+    ).toEqual({ paddingLeft: '1px' })
+  })
 })

--- a/packages/fela-plugin-custom-property/src/index.js
+++ b/packages/fela-plugin-custom-property/src/index.js
@@ -24,7 +24,7 @@ function resolveCustomProperty(
       }
     }
 
-    if (isPlainObject(value)) {
+    if (style.hasOwnProperty(property) && isPlainObject(value)) {
       style[property] = resolveCustomProperty(value, properties, renderer)
     }
   }


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guide-lines at the bottom.
------------------------------------------->

## Description
If value is object it should be resolved as nested style object only if its property was not removed before. Righ now I get warnings each time I use custom propertiy which receives object 

## Example
If required, add a code example or a link to a working example (repository).

```javascript
export default createRenderer({
  plugins: [
    customProperty({
      padding: ({ t, l, b, r }) => {
        const obj = {}

        if (t != null) obj.paddingTop = t
        if (l != null) obj.paddingLeft = l
        if (b != null) obj.paddingBottom = b
        if (r != null) obj.paddingRight = r

        return obj
      }
    })
  ],
})
```

## Versioning
<!------------------------------------------
  Please add all updated packages and propose new versions following the semantic versioning guidelines
------------------------------------------->
#### Major

#### Minor

#### Patch

- fela-plugin-custom-property

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types