### PR TITLE
fix: theme argument of FelaComponent style prop

### DIFF
--- a/packages/fela-bindings/src/FelaComponentFactory.js
+++ b/packages/fela-bindings/src/FelaComponentFactory.js
@@ -1,6 +1,4 @@
 /* @flow */
-import { combineRules } from 'fela'
-
 import resolveRule from './resolveRule'
 
 export default function FelaComponentFactory(
@@ -11,11 +9,9 @@ export default function FelaComponentFactory(
   function FelaComponent({ render = 'div', style, children }, { renderer }) {
     return createElement(FelaTheme, {
       render: theme => {
-        const props = { theme }
-
         const className = renderer._renderStyle(
-          resolveRule(style, props, renderer),
-          props
+          resolveRule(style, theme, renderer),
+          theme
         )
 
         if (render instanceof Function) {

--- a/packages/fela-bindings/src/__tests__/FelaComponent-test.js
+++ b/packages/fela-bindings/src/__tests__/FelaComponent-test.js
@@ -54,7 +54,7 @@ describe('Using the FelaComponent component', () => {
 
     const wrapper = mount(
       <FelaComponent
-        style={({ theme }) => ({
+        style={theme => ({
           fontSize: theme.fontSize,
           color: 'red',
         })}


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guide-lines at the bottom.
------------------------------------------->

## Description
`theme` was passed to the callback as a key inside an object
and is now just passed as is.

## Versioning
<!------------------------------------------
  Please add all updated packages and propose new versions following the semantic versioning guidelines
------------------------------------------->


#### Major

#### Minor

#### Patch
fela-bindings

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

