### PR TITLE
feature(FelaComponent): add rule prop

### DIFF
--- a/docs/api/bindings/FelaComponent.md
+++ b/docs/api/bindings/FelaComponent.md
@@ -7,6 +7,7 @@ FelaComponent is an alternative component to the [createComponent](createCompone
 | Property | Type | Default | Description |
 | --- | --- | --- | --- |
 | style | [*StyleObject*](../../basics/Rules.md#styleobject)<br>*Function*| | Either a valid style object or a function of `theme` |
+| rule | *Function*| | A function of `theme` and props|
 | render | *string?*<br>*Function* | `div` | Either a render function or a string primitive to render into.<br>If passing a render function is receives the specified render interface. |
 
 #### Interface
@@ -63,6 +64,32 @@ To access theme properties, we can simply pass a function of theme.
   })}
   render={({ className, theme }) => (
     <div className={className}>I am red on {theme.bgPrimary}.</div>
+  )}
+/>
+```
+
+#### Style Rule as a Function of Props and Theme
+Sometimes it is desirable to style a component as a function of both theme and
+props. The `rule` prop takes a callback, and passes it an object with `theme`
+and all props passed to FelaComponent except "style", "render" and "rule".
+
+This provides an API that is both compatible with createComponent, and allows
+using an externally defined function in such use cases. Hopefully, this can
+be help performance in hot paths by not requiring a function to be created on
+every render.
+
+
+```javascript
+const ruleFunction = ({ theme, bgc }) => ({
+  backgroundColor: bgc || 'red',
+  color: theme.bgPrimary,
+})
+
+<FelaComponent
+  bgc='blue',
+  rule={ruleFunction}
+  render={({ className, theme }) => (
+    <div className={className}>I am {theme.bgPrimary} on {bgc || 'red'}.</div>
   )}
 />
 ```

--- a/packages/fela-bindings/src/FelaComponentFactory.js
+++ b/packages/fela-bindings/src/FelaComponentFactory.js
@@ -1,6 +1,4 @@
 /* @flow */
-import { combineRules } from 'fela'
-
 import resolveRule from './resolveRule'
 
 export default function FelaComponentFactory(
@@ -8,13 +6,16 @@ export default function FelaComponentFactory(
   FelaTheme: Function,
   contextTypes?: Object
 ): Function {
-  function FelaComponent({ render = 'div', style, children }, { renderer }) {
+  function FelaComponent(
+    { render = 'div', style, rule, children, ...restProps },
+    { renderer }
+  ) {
     return createElement(FelaTheme, {
       render: theme => {
-        const props = { theme }
+        const props = rule ? { theme, ...restProps } : theme
 
         const className = renderer._renderStyle(
-          resolveRule(style, props, renderer),
+          resolveRule(rule || style, props, renderer),
           props
         )
 

--- a/packages/fela-bindings/src/__tests__/FelaComponent-test.js
+++ b/packages/fela-bindings/src/__tests__/FelaComponent-test.js
@@ -45,7 +45,7 @@ describe('Using the FelaComponent component', () => {
     expect([css(renderToString(renderer)), toJson(wrapper)]).toMatchSnapshot()
   })
 
-  it('correctly pass the theme', () => {
+  it('correctly pass the theme to the "style" prop', () => {
     const themeContext = createTheme({
       fontSize: '15px',
     })
@@ -54,9 +54,40 @@ describe('Using the FelaComponent component', () => {
 
     const wrapper = mount(
       <FelaComponent
-        style={({ theme }) => ({
+        style={theme => ({
           fontSize: theme.fontSize,
           color: 'red',
+        })}
+        render={({ className, theme }) => (
+          <div className={className}>
+            I am red and written in {theme.fontSize}.
+          </div>
+        )}
+      />,
+      {
+        context: {
+          [THEME_CHANNEL]: themeContext,
+          renderer,
+        },
+      }
+    )
+
+    expect([css(renderToString(renderer)), toJson(wrapper)]).toMatchSnapshot()
+  })
+
+  it('correctly pass the theme and other props to the "rule" prop', () => {
+    const themeContext = createTheme({
+      fontSize: '15px',
+    })
+
+    const renderer = createRenderer()
+
+    const wrapper = mount(
+      <FelaComponent
+        bgc="blue"
+        rule={({ theme, bgc }) => ({
+          fontSize: theme.fontSize,
+          backgroundColor: bgc || 'red',
         })}
         render={({ className, theme }) => (
           <div className={className}>

--- a/packages/fela-bindings/src/__tests__/__snapshots__/FelaComponent-test.js.snap
+++ b/packages/fela-bindings/src/__tests__/__snapshots__/FelaComponent-test.js.snap
@@ -1,6 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Using the FelaComponent component correctly pass the theme 1`] = `
+exports[`Using the FelaComponent component correctly pass the theme and other props to the "rule" prop 1`] = `
+Array [
+  ".a {
+    font-size: 15px
+}
+
+.b {
+    background-color: blue
+}",
+  <FelaComponent
+    bgc="blue"
+    render={[Function]}
+    rule={[Function]}
+>
+    <FelaTheme
+        render={[Function]}
+    >
+        <div
+            className="a b"
+        >
+            I am red and written in 
+            15px
+            .
+        </div>
+    </FelaTheme>
+</FelaComponent>,
+]
+`;
+
+exports[`Using the FelaComponent component correctly pass the theme to the "style" prop 1`] = `
 Array [
   ".a {
     font-size: 15px


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guide-lines at the bottom.
------------------------------------------->

## Description
* Add a rule prop to FelaComponent, that passes the callback
  an object with the theme and all props passed to FelaComponent except
  "style", "render" and "rule". This provides an API that is compatible
  with createComponent, and allows using an externally defined function
  when style is a function of both props and theme. Hopefully, this can
  be help perforamnce in hot paths by not requiring a function to be
  created on every render.
* Fix how "theme" was passed to the "style" prop. It was previously
  passed inside an object instead and is now passed as the argument
  itself.
* Update tests and documentation.

This pull request makes #526 redundant as it also solves that problem 

## Example
```javascript
const ruleFunction = ({ theme, bgc }) => ({
  backgroundColor: bgc || 'red',
  color: theme.bgPrimary,
})

<FelaComponent
  bgc='blue',
  rule={ruleFunction}
  render={({ className, theme }) => (
    <div className={className}>I am {theme.bgPrimary} on {bgc || 'red'}.</div>
  )}
/>
```

## Versioning

#### Major

#### Minor
fela-bindings

#### Patch

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types