### PR TITLE
added an option to opt-in CSSLint (disabled by default)

### DIFF
--- a/packages/fela-plugin-validator/README.md
+++ b/packages/fela-plugin-validator/README.md
@@ -2,8 +2,10 @@
 
 <img alt="npm version" src="https://badge.fury.io/js/fela-plugin-validator.svg"> <img alt="npm downloads" src="https://img.shields.io/npm/dm/fela-plugin-validator.svg">
 
-Enforces object validation for keyframes and rules.
-Logs invalid properties to the `console`. A [csslint](https://github.com/CSSLint/csslint) is used to check the CSS. One might also enable automatic property deletion.
+Enforces object validation for keyframes and rules.<br>
+Logs invalid properties to the `console`. <br>
+If enabled, [csslint](https://github.com/CSSLint/csslint) is used to check the CSS.<br>
+One might also enable automatic property deletion.
 
 ## Installation
 ```sh
@@ -32,8 +34,9 @@ Make sure that you place the validator plugin *at the end* of your plugins array
 ##### Options
 | Option | Value | Default | Description |
 | --- | --- | --- | --- |
-| `logInvalid` | *(boolean)* | `true` | logs invalid properties/values |
-| `deleteInvalid` | *(boolean)* | `false` | deletes invalid properties/values |
+| logInvalid | *(boolean?)* | `true` | logs invalid properties/values |
+| deleteInvalid | *(boolean?)* | `false` | deletes invalid properties/values |
+| useCSSLint | *(boolean?)* | `false` | use CSSLint for style validation |
 
 ##### Example
 ```javascript
@@ -42,7 +45,8 @@ import validator from 'fela-plugin-validator'
 
 const validatorPlugin = validator({
   logInvalid: true,
-  deleteInvalid: true
+  deleteInvalid: true,
+  useCSSLint: true
 })
 
 const renderer = createRenderer({

--- a/packages/fela-plugin-validator/package.json
+++ b/packages/fela-plugin-validator/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "css-in-js-utils": "^2.0.0",
     "csslint": "^1.0.5",
-    "fela-utils": "^8.0.4"
+    "fela-utils": "^8.0.4",
+    "isobject": "^3.0.1"
   }
 }

--- a/packages/fela-plugin-validator/src/__tests__/__snapshots__/validator-test.js.snap
+++ b/packages/fela-plugin-validator/src/__tests__/__snapshots__/validator-test.js.snap
@@ -1,6 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Validator plugin should log into the console an error about the incorrect nested style 1`] = `
+exports[`Validator plugin should log into the console an error about the invalid keyframe 1`] = `
+Array [
+  Array [
+    " Invalid keyframe value. An object was expected.",
+    Object {
+      "percentage": "from",
+      "style": 10,
+    },
+  ],
+  Array [
+    " Invalid keyframe value. An object was expected.",
+    Object {
+      "percentage": "to",
+      "style": 20,
+    },
+  ],
+]
+`;
+
+exports[`Validator plugin with useCSSLint should log into the console an error about the incorrect nested style 1`] = `
 Array [
   Array [
     " Invalid property \\"fontSize\\" with value \\"abc\\". Expected (<font-size>) but found 'abc'.",
@@ -12,7 +31,7 @@ Array [
 ]
 `;
 
-exports[`Validator plugin should log into the console an error about the incorrect style 1`] = `
+exports[`Validator plugin with useCSSLint should log into the console an error about the incorrect style 1`] = `
 Array [
   Array [
     " Invalid property \\"fontSize\\" with value \\"abc\\". Expected (<font-size>) but found 'abc'.",
@@ -24,7 +43,7 @@ Array [
 ]
 `;
 
-exports[`Validator plugin should log into the console an error about the incorrect style in keyframe 1`] = `
+exports[`Validator plugin with useCSSLint should log into the console an error about the incorrect style in keyframe 1`] = `
 Array [
   Array [
     " Invalid property \\"fontSize\\" with value \\"10pxp\\". Unexpected token '10pxp'.",
@@ -50,26 +69,7 @@ Array [
 ]
 `;
 
-exports[`Validator plugin should log into the console an error about the invalid keyframe 1`] = `
-Array [
-  Array [
-    " Invalid keyframe value. An object was expected.",
-    Object {
-      "percentage": "from",
-      "style": 10,
-    },
-  ],
-  Array [
-    " Invalid keyframe value. An object was expected.",
-    Object {
-      "percentage": "to",
-      "style": 20,
-    },
-  ],
-]
-`;
-
-exports[`Validator plugin should log into the console an error about the invalid keyframe property 1`] = `
+exports[`Validator plugin with useCSSLint should log into the console an error about the invalid keyframe property 1`] = `
 Array [
   Array [
     " Invalid keyframe property.
@@ -94,7 +94,7 @@ Array [
 ]
 `;
 
-exports[`Validator plugin should log into the console an error about the invalid nested property 1`] = `
+exports[`Validator plugin with useCSSLint should log into the console an error about the invalid nested property 1`] = `
 Array [
   Array [
     " Invalid nested property. Only use nested media queries, pseudo classes, child selectors or &-combinators.

--- a/packages/fela-plugin-validator/src/__tests__/validator-test.js
+++ b/packages/fela-plugin-validator/src/__tests__/validator-test.js
@@ -25,53 +25,6 @@ describe('Validator plugin', () => {
     expect(consoleSpy.mock.calls).toHaveLength(0)
   })
 
-  it('should log into the console an error about the incorrect style', () => {
-    validator()(
-      {
-        fontSize: 'abc',
-      },
-      RULE_TYPE
-    )
-
-    expect(consoleSpy.mock.calls).toMatchSnapshot()
-  })
-
-  it('should log into the console an error about the incorrect nested style', () => {
-    validator()(
-      {
-        ':hover': {
-          fontSize: 'abc',
-        },
-      },
-      RULE_TYPE
-    )
-
-    expect(consoleSpy.mock.calls).toMatchSnapshot()
-  })
-
-  it('should log into the console an error about the invalid nested property', () => {
-    validator()(
-      {
-        'wrong nested property': {},
-      },
-      RULE_TYPE
-    )
-
-    expect(consoleSpy.mock.calls).toMatchSnapshot()
-  })
-
-  it('should be an empty console output for correct keyframe', () => {
-    validator()(
-      {
-        from: { fontSize: '10px' },
-        to: { fontSize: '12px' },
-      },
-      KEYFRAME_TYPE
-    )
-
-    expect(consoleSpy.mock.calls).toHaveLength(0)
-  })
-
   it('should log into the console an error about the invalid keyframe', () => {
     validator()(
       {
@@ -84,27 +37,76 @@ describe('Validator plugin', () => {
     expect(consoleSpy.mock.calls).toMatchSnapshot()
   })
 
-  it('should log into the console an error about the invalid keyframe property', () => {
-    validator()(
-      {
-        start: { fontSize: '10pxp' },
-        end: { fontSiz: '12px' },
-      },
-      KEYFRAME_TYPE
-    )
+  describe('with useCSSLint', () => {
+    it('should log into the console an error about the incorrect style', () => {
+      validator({ useCSSLint: true })(
+        {
+          fontSize: 'abc',
+        },
+        RULE_TYPE
+      )
 
-    expect(consoleSpy.mock.calls).toMatchSnapshot()
-  })
+      expect(consoleSpy.mock.calls).toMatchSnapshot()
+    })
 
-  it('should log into the console an error about the incorrect style in keyframe', () => {
-    validator()(
-      {
-        from: { fontSize: '10pxp' },
-        to: { fontSiz: '12px' },
-      },
-      KEYFRAME_TYPE
-    )
+    it('should log into the console an error about the incorrect nested style', () => {
+      validator({ useCSSLint: true })(
+        {
+          ':hover': {
+            fontSize: 'abc',
+          },
+        },
+        RULE_TYPE
+      )
 
-    expect(consoleSpy.mock.calls).toMatchSnapshot()
+      expect(consoleSpy.mock.calls).toMatchSnapshot()
+    })
+
+    it('should log into the console an error about the invalid nested property', () => {
+      validator({ useCSSLint: true })(
+        {
+          'wrong nested property': {},
+        },
+        RULE_TYPE
+      )
+
+      expect(consoleSpy.mock.calls).toMatchSnapshot()
+    })
+
+    it('should be an empty console output for correct keyframe', () => {
+      validator({ useCSSLint: true })(
+        {
+          from: { fontSize: '10px' },
+          to: { fontSize: '12px' },
+        },
+        KEYFRAME_TYPE
+      )
+
+      expect(consoleSpy.mock.calls).toHaveLength(0)
+    })
+
+    it('should log into the console an error about the invalid keyframe property', () => {
+      validator({ useCSSLint: true })(
+        {
+          start: { fontSize: '10pxp' },
+          end: { fontSiz: '12px' },
+        },
+        KEYFRAME_TYPE
+      )
+
+      expect(consoleSpy.mock.calls).toMatchSnapshot()
+    })
+
+    it('should log into the console an error about the incorrect style in keyframe', () => {
+      validator({ useCSSLint: true })(
+        {
+          from: { fontSize: '10pxp' },
+          to: { fontSiz: '12px' },
+        },
+        KEYFRAME_TYPE
+      )
+
+      expect(consoleSpy.mock.calls).toMatchSnapshot()
+    })
   })
 })

--- a/packages/fela-plugin-validator/src/index.js
+++ b/packages/fela-plugin-validator/src/index.js
@@ -7,13 +7,10 @@ import {
   isSupport,
 } from 'fela-utils'
 import cssifyDeclaration from 'css-in-js-utils/lib/cssifyDeclaration'
+import isPlainObject from 'isobject'
 import { CSSLint } from 'csslint'
 
 import type { StyleType } from '../../../flowtypes/StyleType'
-
-function isPlainObject(obj: any): boolean {
-  return typeof obj === 'object' && !Array.isArray(obj)
-}
 
 function handleError(
   property: string,
@@ -35,7 +32,8 @@ function handleError(
 function validateStyleObject(
   style: Object,
   logInvalid: boolean,
-  deleteInvalid: boolean
+  deleteInvalid: boolean,
+  useCSSLint: boolean
 ): void {
   for (const property in style) {
     const value = style[property]
@@ -46,7 +44,7 @@ function validateStyleObject(
         isMediaQuery(property) ||
         isSupport(property)
       ) {
-        validateStyleObject(value, logInvalid, deleteInvalid)
+        validateStyleObject(value, logInvalid, deleteInvalid, useCSSLint)
       } else {
         handleError(
           property,
@@ -62,25 +60,28 @@ function validateStyleObject(
         )
       }
     } else {
-      const { messages } = CSSLint.verify(
-        `.fela {${cssifyDeclaration(property, value)};}`
-      )
-      messages.forEach(({ message }) => {
-        handleError(
-          property,
-          style,
-          logInvalid,
-          deleteInvalid,
-          `Invalid property "${property}" with value "${value}". ${message.replace(
-            / at line .+, col .+\./,
-            '.'
-          )}`,
-          {
-            property,
-            value,
-          }
+      if (useCSSLint) {
+        const { messages } = CSSLint.verify(
+          `.fela {${cssifyDeclaration(property, value)};}`
         )
-      })
+
+        messages.forEach(({ message }) => {
+          handleError(
+            property,
+            style,
+            logInvalid,
+            deleteInvalid,
+            `Invalid property "${property}" with value "${value}". ${message.replace(
+              / at line .+, col .+\./,
+              '.'
+            )}`,
+            {
+              property,
+              value,
+            }
+          )
+        })
+      }
     }
   }
 }
@@ -97,7 +98,8 @@ function isValidPercentage(percentage: string): boolean {
 function validateKeyframeObject(
   style: Object,
   logInvalid: boolean,
-  deleteInvalid: boolean
+  deleteInvalid: boolean,
+  useCSSLint: boolean
 ): void {
   for (const percentage in style) {
     const value = style[percentage]
@@ -132,7 +134,7 @@ function validateKeyframeObject(
         }
       )
     } else {
-      validateStyleObject(value, logInvalid, deleteInvalid)
+      validateStyleObject(value, logInvalid, deleteInvalid, useCSSLint)
     }
   }
 }
@@ -142,12 +144,12 @@ function validateStyle(
   type: StyleType,
   options: Object
 ): Object {
-  const { logInvalid, deleteInvalid } = options
+  const { logInvalid, deleteInvalid, useCSSLint } = options
 
   if (type === KEYFRAME_TYPE) {
-    validateKeyframeObject(style, logInvalid, deleteInvalid)
+    validateKeyframeObject(style, logInvalid, deleteInvalid, useCSSLint)
   } else if (type === RULE_TYPE) {
-    validateStyleObject(style, logInvalid, deleteInvalid)
+    validateStyleObject(style, logInvalid, deleteInvalid, useCSSLint)
   }
 
   return style
@@ -156,6 +158,7 @@ function validateStyle(
 const defaultOptions = {
   logInvalid: true,
   deleteInvalid: false,
+  useCSSLint: false,
 }
 
 export default function validator(options: Object = {}) {

--- a/packages/fela-plugin-validator/yarn.lock
+++ b/packages/fela-plugin-validator/yarn.lock
@@ -23,6 +23,10 @@ hyphenate-style-name@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz#31160a36930adaf1fc04c6074f7eb41465d4ec4b"
 
+isobject@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
+
 parserlib@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/parserlib/-/parserlib-1.1.1.tgz#a64cfa724062434fdfc351c9a4ec2d92b94c06f4"

--- a/packages/fela/README.md
+++ b/packages/fela/README.md
@@ -216,9 +216,11 @@ We'd love to help out. We also highly appreciate any feedback.
 - [Lusk](https://lusk.io)
 - [MediaFire](https://m.mediafire.com)
 - [N26](https://n26.com)
+- [Net-A-Porter](https://www.net-a-porter.com/gb/en/porter)
 - [NinjaConcept](https://www.ninjaconcept.com)
 - [Optisure](https://www.optisure.de)
 - [Rocket Station](http://rstation.io)
+- [Space Between](https://www.spacebetween.co.uk/)
 - [V2](https://www.v2.com)
 
 


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guide-lines at the bottom.
------------------------------------------->

## Description
For now, we disable CSSLint by default.
We could add a major release to enable it by default, but the last release broke semver again.

## Versioning
<!------------------------------------------
  Please add all updated packages and propose new versions following the semantic versioning guidelines
------------------------------------------->


#### Major

#### Minor

#### Patch
fela-plugin-validator

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

