### PR TITLE
docs(test): fix theme in Enzyme example

### DIFF
--- a/docs/recipes/TestingFelaComponents.md
+++ b/docs/recipes/TestingFelaComponents.md
@@ -312,11 +312,11 @@ const mount = (node, options = {}) => {
   const component = enzymeMount(node, {
     childContextTypes: {
       renderer: PropTypes.object,
-      theme: PropTypes.object
+      _FELA_THEME_: PropTypes.object
     },
     context: {
       renderer,
-      theme: createTheme(myTheme)
+      _FELA_THEME_: createTheme(myTheme)
     },
     ...options
   })


### PR DESCRIPTION
## Description
The enzyme example in the docs attached the theme to the `theme` key instead of `_FELA_THEME_` in the context. 


## Versioning
This change should not result in a release

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

