### PR TITLE
Fix rehydrated twice generated monolitihic classes

### DIFF
--- a/packages/fela-dom/src/dom/rehydration/rehydrate.js
+++ b/packages/fela-dom/src/dom/rehydration/rehydrate.js
@@ -34,4 +34,6 @@ export default function rehydrate(renderer: DOMRenderer): void {
       }
     }
   })
+
+  renderer._emitChange({ type: 'REHYDRATATION_FINISHED' })
 }

--- a/packages/fela-monolithic/src/index.js
+++ b/packages/fela-monolithic/src/index.js
@@ -27,9 +27,6 @@ function useMonolithicRenderer(
 ): MonolithicRenderer {
   renderer.prettySelectors = prettySelectors
 
-  // monolithic output can not be rehydrated
-  renderer.enableRehydration = false
-
   renderer._renderStyleToCache = (
     className: string,
     style: Object,
@@ -139,6 +136,22 @@ function useMonolithicRenderer(
     )
     return renderer._renderStyleToClassNames(processedStyle, rule)
   }
+
+  renderer.subscribe(event => {
+    if (event.type === 'REHYDRATATION_FINISHED') {
+      // Repair cache for monolithic usage
+      renderer.cache = Object.keys(renderer.cache).reduce((acc, key) => {
+        const item = renderer.cache[key]
+        if (item.type === 'RULE') {
+          return Object.assign(acc, {
+            [item.className + item.media + item.support]: item,
+          })
+        }
+        return Object.assign(acc, { [key]: item })
+      }, {})
+    }
+  })
+
 
   return renderer
 }


### PR DESCRIPTION
## Description
This is related with old closed issue #395. You need to use monolithic enhancer. It causes twice rendered classes in DOM (is annoying for development). The first set is from SSR and next set is generated because of wrongly cached classes to monolithic usage. Fela tries to rehydrate generated monolithic classes. They are rehydrated properly, but not for monolithic usage. There are too long keys in renderer cache (because of multiple rules per class). So i added repair function to fix rehydrated cache to work properly with monolithic enhancer.

## Example
```javascript
const renderer = createRenderer({
  plugins: [
    ...
  ],
  enhancers: [monolithic()]
});
```

## Versioning
<!------------------------------------------
  Please add all updated packages and propose new versions following the semantic versioning guidelines
------------------------------------------->

#### Patch
fela-dom
fela-monolithic

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

