### PR TITLE
Concatenate "customClass" with generated classes in felaComponent

### DIFF
--- a/docs/api/bindings/FelaComponent.md
+++ b/docs/api/bindings/FelaComponent.md
@@ -6,6 +6,7 @@ FelaComponent is an alternative component to the [createComponent](createCompone
 
 | Property | Type | Default | Description |
 | --- | --- | --- | --- |
+| customClass | string | class(es) to prepend before the generated classes |
 | style | [*StyleObject*](../../basics/Rules.md#styleobject)<br>*Function*| | Either a valid style object or a function of `theme` |
 | rule | *Function*| | A function of `theme` and props|
 | render | *string?*<br>*Function* | `div` | Either a render function or a string primitive to render into.<br>If passing a render function is receives the specified render interface. |
@@ -108,4 +109,21 @@ Children will automatically be passed down. If not specified at all, it will ren
 >
   I am red on blue
 </FelaComponent>
+```
+
+#### Add Custom Classes
+The common use case of needing to add a custom class to the generated ones, e.g.
+for integration with 3rd party libraries, can be handled using the `customClass`
+prop.
+
+```javascript
+<FelaComponent
+  customClass="my-custom-class"
+  style={{ color: 'red' }}
+>
+  I am red and have a custom class
+</FelaComponent>
+// <div class="my-custom-class a">
+//  I am red and have a custom class
+// </div>
 ```

--- a/packages/fela-bindings/src/FelaComponentFactory.js
+++ b/packages/fela-bindings/src/FelaComponentFactory.js
@@ -7,17 +7,19 @@ export default function FelaComponentFactory(
   contextTypes?: Object
 ): Function {
   function FelaComponent(
-    { render = 'div', style, rule, children, ...restProps },
+    { children, customClass, render = 'div', rule, style, ...restProps },
     { renderer }
   ) {
     return createElement(FelaTheme, {
       render: theme => {
         const props = rule ? { theme, ...restProps } : theme
 
-        const className = renderer._renderStyle(
+        const className = `${customClass
+          ? `${customClass} `
+          : ''}${renderer._renderStyle(
           resolveRule(rule || style, props, renderer),
           props
-        )
+        )}`
 
         if (render instanceof Function) {
           return render({

--- a/packages/fela-bindings/src/__tests__/FelaComponent-test.js
+++ b/packages/fela-bindings/src/__tests__/FelaComponent-test.js
@@ -45,6 +45,29 @@ describe('Using the FelaComponent component', () => {
     expect([css(renderToString(renderer)), toJson(wrapper)]).toMatchSnapshot()
   })
 
+  it('correctly concat "customClass" with className', () => {
+    const renderer = createRenderer()
+
+    const wrapper = mount(
+      <FelaComponent
+        customClass="custom-class"
+        style={{
+          color: 'red',
+        }}
+        render={({ className }) => (
+          <div className={className}>I am red and have a custom class.</div>
+        )}
+      />,
+      {
+        context: {
+          renderer,
+        },
+      }
+    )
+
+    expect([css(renderToString(renderer)), toJson(wrapper)]).toMatchSnapshot()
+  })
+
   it('correctly pass the theme to the "style" prop', () => {
     const themeContext = createTheme({
       fontSize: '15px',

--- a/packages/fela-bindings/src/__tests__/__snapshots__/FelaComponent-test.js.snap
+++ b/packages/fela-bindings/src/__tests__/__snapshots__/FelaComponent-test.js.snap
@@ -1,5 +1,32 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Using the FelaComponent component correctly concat "customClass" with className 1`] = `
+Array [
+  ".a {
+    color: red
+}",
+  <FelaComponent
+    customClass="custom-class"
+    render={[Function]}
+    style={
+        Object {
+            "color": "red",
+          }
+    }
+>
+    <FelaTheme
+        render={[Function]}
+    >
+        <div
+            className="custom-class a"
+        >
+            I am red and have a custom class.
+        </div>
+    </FelaTheme>
+</FelaComponent>,
+]
+`;
+
 exports[`Using the FelaComponent component correctly pass the theme and other props to the "rule" prop 1`] = `
 Array [
   ".a {


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guide-lines at the bottom.
------------------------------------------->

## Description
As discussed in #558, this pull request adds a `customClass` prop to `FelaComponent`, which takes a string with will be concatenated with the generated classes.

I'd be happy for input on the API choice of using `customClass`

## Example
```javascript
<FelaComponent
  customClass="my-custom-class"
  style={{ color: 'red' }}
>
  I am red and have a custom class
</FelaComponent>
// <div class="my-custom-class a">
//  I am red and have a custom class
// </div>
```
## Versioning
<!------------------------------------------
  Please add all updated packages and propose new versions following the semantic versioning guidelines
------------------------------------------->


#### Major

#### Minor
fela-bindings

#### Patch

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

