### PR TITLE
No longer append unit to zero-values in unit plugin

### DIFF
--- a/packages/fela-plugin-unit/README.md
+++ b/packages/fela-plugin-unit/README.md
@@ -3,7 +3,7 @@
 <img alt="npm version" src="https://badge.fury.io/js/fela-plugin-unit.svg"> <img alt="npm downloads" src="https://img.shields.io/npm/dm/fela-plugin-unit.svg">
 
 Always writing length values as string with a value applied seems not like the JavaScript way to do it. You can also use mathematics to process number values. <br>
-It is aware of unitless properties such as `lineHeight` and also adds units to multiple values inside an array.
+It is aware of unitless properties such as `lineHeight`, zero-values and also adds units to multiple values inside an array.
 
 ## Installation
 ```sh
@@ -54,6 +54,7 @@ Using the above example code:
 #### Input
 ```javascript
 {
+  marginTop: 0,
   width: 25,
   lineHeight: 1.4,
   height: '53',
@@ -64,6 +65,7 @@ Using the above example code:
 #### Output
 ```javascript
 {
+  marginTop: 0,
   width: '25em',
   lineHeight: 1.4,
   height: '53em',

--- a/packages/fela-plugin-unit/src/__tests__/unit-test.js
+++ b/packages/fela-plugin-unit/src/__tests__/unit-test.js
@@ -76,4 +76,16 @@ describe('Unit plugin', () => {
       fontSize: '15pt',
     })
   })
+
+  it('should not add unit to 0', () => {
+    const style = {
+      width: 0,
+      height: '0',
+    }
+
+    expect(unit('px')(style)).toEqual({
+      width: 0,
+      height: '0',
+    })
+  })
 })

--- a/packages/fela-plugin-unit/src/index.js
+++ b/packages/fela-plugin-unit/src/index.js
@@ -10,8 +10,9 @@ function addUnitIfNeeded(
   const valueType = typeof value
   /* eslint-disable eqeqeq */
   if (
-    valueType === 'number' ||
-    (valueType === 'string' && value == parseFloat(value))
+    (valueType === 'number' ||
+      (valueType === 'string' && value == parseFloat(value))) &&
+    value != 0
   ) {
     value += propertyUnit
   }


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guide-lines at the bottom.
------------------------------------------->

## Description

There is no need to add a unit for a zero (`0`) value (unless it is a duration, which is of no concern for this plugin). This pull-request no longer add a unit for these values.

## Versioning
<!------------------------------------------
  Please add all updated packages and propose new versions following the semantic versioning guidelines
------------------------------------------->

#### Patch

* `fela-plugin-unit`

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

