### PR TITLE
Add support for custom isUnitlessProperty

### DIFF
--- a/packages/fela-plugin-unit/README.md
+++ b/packages/fela-plugin-unit/README.md
@@ -31,6 +31,7 @@ const renderer = createRenderer({
 | --- | --- | --- | --- |
 | unit | `ch`, `em`, `ex`, `rem`, `vh`, `vw`, `vmin`, `vmax`, `px`, `cm`, `mm`, `in`, `pc`, `pt`, `mozmm` | `px` | unit which gets applied |
 | unitPerProperty | *(Object)* | `{}` | Default units per property |
+| isUnitlessProperty | *(Function)* | [`util function`](https://github.com/rofrischmann/css-in-js-utils/blob/master/modules/isUnitlessProperty.js) | check whether property should remain unitless |
 
 ##### Example
 ```javascript

--- a/packages/fela-plugin-unit/src/__tests__/unit-test.js
+++ b/packages/fela-plugin-unit/src/__tests__/unit-test.js
@@ -88,4 +88,35 @@ describe('Unit plugin', () => {
       height: '0',
     })
   })
+
+  it('should support custom isUnitlessProperty', () => {
+    const style = {
+      fontSize: 15,
+      height: 50,
+      lineHeight: 15,
+      margin: 10,
+      width: 46,
+      zIndex: 1,
+    }
+
+    const isUnitlessProperty = prop => prop === 'zIndex'
+
+    expect(
+      unit(
+        'px',
+        {
+          fontSize: 'pt',
+          margin: '%',
+        },
+        isUnitlessProperty
+      )(style)
+    ).toEqual({
+      fontSize: '15pt',
+      height: '50px',
+      lineHeight: '15px',
+      margin: '10%',
+      width: '46px',
+      zIndex: 1,
+    })
+  })
 })

--- a/packages/fela-plugin-unit/src/index.js
+++ b/packages/fela-plugin-unit/src/index.js
@@ -1,5 +1,5 @@
 /* @flow */
-import isUnitlessProperty from 'css-in-js-utils/lib/isUnitlessProperty'
+import defaultIsUnitlessProperty from 'css-in-js-utils/lib/isUnitlessProperty'
 import isPlainObject from 'isobject'
 
 function addUnitIfNeeded(
@@ -23,7 +23,8 @@ function addUnitIfNeeded(
 function addUnit(
   style: Object,
   defaultUnit: string,
-  propertyMap: Object
+  propertyMap: Object,
+  isUnitlessProperty: Function
 ): Object {
   for (const property in style) {
     if (!isUnitlessProperty(property)) {
@@ -31,7 +32,12 @@ function addUnit(
       const propertyUnit = propertyMap[property] || defaultUnit
 
       if (isPlainObject(cssValue)) {
-        style[property] = addUnit(cssValue, defaultUnit, propertyMap)
+        style[property] = addUnit(
+          cssValue,
+          defaultUnit,
+          propertyMap,
+          isUnitlessProperty
+        )
       } else if (Array.isArray(cssValue)) {
         style[property] = cssValue.map(val =>
           addUnitIfNeeded(property, val, propertyUnit)
@@ -47,7 +53,9 @@ function addUnit(
 
 export default function unit(
   defaultUnit: string = 'px',
-  propertyMap: Object = {}
+  propertyMap: Object = {},
+  isUnitlessProperty: Function = defaultIsUnitlessProperty
 ) {
-  return (style: Object) => addUnit(style, defaultUnit, propertyMap)
+  return (style: Object) =>
+    addUnit(style, defaultUnit, propertyMap, isUnitlessProperty)
 }


### PR DESCRIPTION
## Description

Adds an extra argument to `fela-plugin-unit` which allows users to define a custom `isUnitlessProperty` check function.

In `react-native`, `lineHeight` is a unitless value which equates to `px` in web. So that we can build native-first, we'd like to use a custom `isUnitlessProperty` function which does not include `lineHeight`; we'd then be able to have `lineHeight: 15` transformed to `lineHeight: '15px'` for example.

## Example

```js
import isUnitless from 'css-in-js-utils/lib/isUnitlessProperty'

const addUnitsTo = {
	lineHeight: true
}

const isUnitlessProperty = prop => addUnitsTo[prop]
	? false
	: isUnitless(prop)

unit(
	'px',
	{},
	isUnitlessProperty
)(style)
```

## Versioning

#### Minor

`fela-plugin-unit`

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

---

Note: `yarn check` failed, but running the four commands separately worked. Wasn't sure whether the example should include the new function; feels like it's not necessary, since it's a more advanced feature, but happy to add in if desired.

Also happy to consider different approaches - thought of a couple more, but this felt like the right place to add it!