### PR TITLE
fix renderer bug under safari

### DIFF
--- a/packages/fela-bindings/src/ProviderFactory.js
+++ b/packages/fela-bindings/src/ProviderFactory.js
@@ -4,6 +4,7 @@ import objectEach from 'fast-loops/lib/objectEach'
 
 function hasDOM(renderer) {
   return (
+    renderer &&
     !renderer.isNativeRenderer &&
     typeof window !== 'undefined' &&
     window.document &&


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guide-lines at the bottom.
------------------------------------------->

## Description
After update from next 5 to next 6, everything was working correctly except safari styling. Either two things happened:  
 

- infinite reload with webpack under development mode
- classes got assigned to other elements as well, not just components which were using it, resulting in wrong styling

## Example
I've already spent a couple of hours trying to make such a project for bug demo, but I don't consider that it worth the effort considering the simplicity of the fix.

## Versioning
<!------------------------------------------
  Please add all updated packages and propose new versions following the semantic versioning guidelines
------------------------------------------->



#### Minor
`fela-bindings`

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

