### PR TITLE
Deprecate: babel-plugin-fela

### DIFF
--- a/packages/babel-plugin-fela/README.md
+++ b/packages/babel-plugin-fela/README.md
@@ -1,3 +1,6 @@
+> **Deprecated!**<br>The Fela Babel plugin (babel-plugin-fela) is deprecated, please remove it from your Babel configuration.<br>
+It's use could lead to false output with newer Fela versions and doesn't add much value at all.
+
 # babel-plugin-fela
 
 A babel plugin to optimize Fela rules.<br>

--- a/packages/babel-plugin-fela/src/deprecate.js
+++ b/packages/babel-plugin-fela/src/deprecate.js
@@ -1,0 +1,8 @@
+const cache = {}
+
+export default function deprecate(message) {
+  if (process.env.NODE_ENV !== 'production' && !cache[message]) {
+    console.warn(message)
+    cache[message] = true
+  }
+}

--- a/packages/babel-plugin-fela/src/index.js
+++ b/packages/babel-plugin-fela/src/index.js
@@ -1,8 +1,6 @@
 import createPlugin from './createPlugin'
 import deprecate from './deprecate'
 
-deprecate(`
-The Fela Babel plugin (babel-plugin-fela) is deprecated, please remove it from your Babel configuration.
-It's use could lead to false output with newer Fela versions and doesn't add much value at all.
-`)
+deprecate(`The Fela Babel plugin (babel-plugin-fela) is deprecated, please remove it from your Babel configuration.
+It's use could lead to false output with newer Fela versions and doesn't add much value at all.`)
 export default createPlugin()

--- a/packages/babel-plugin-fela/src/index.js
+++ b/packages/babel-plugin-fela/src/index.js
@@ -1,3 +1,8 @@
 import createPlugin from './createPlugin'
+import deprecate from './deprecate'
 
+deprecate(`
+The Fela Babel plugin (babel-plugin-fela) is deprecated, please remove it from your Babel configuration.
+It's use could lead to false output with newer Fela versions and doesn't add much value at all.
+`)
 export default createPlugin()

--- a/packages/babel-plugin-fela/src/index.js
+++ b/packages/babel-plugin-fela/src/index.js
@@ -3,4 +3,5 @@ import deprecate from './deprecate'
 
 deprecate(`The Fela Babel plugin (babel-plugin-fela) is deprecated, please remove it from your Babel configuration.
 It's use could lead to false output with newer Fela versions and doesn't add much value at all.`)
+
 export default createPlugin()


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guide-lines at the bottom.
------------------------------------------->

## Description
This PR deprecated the Babel plugin as it might yield false output with newer Fela versions by splitting rules. It also doesn't add much value at all.

## Versioning
<!------------------------------------------
  Please add all updated packages and propose new versions following the semantic versioning guidelines
------------------------------------------->


#### Major

#### Minor

#### Patch
- babel-plugin-fela

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [ ] Documentation has been added/updated
- [x] My changes have proper flow-types

## ToDo
- [ ] update documentation
- [ ] remove babel-plugin-fela after merge