### PR TITLE
Deprecate: fela-plugin-dynamic-prefixer

### DIFF
--- a/packages/fela-plugin-dynamic-prefixer/README.md
+++ b/packages/fela-plugin-dynamic-prefixer/README.md
@@ -1,3 +1,5 @@
+> **Deprecated!**<br>The dynamic prefixer plugin (fela-plugin-dynamic-prefixer) is deprecated, please remove it from your Fela configuration.<br>inline-style-prefixer will remove its dynamic version due to increasing issues with newer browers, browser detection and false prefixing.<br>Use the static prefixer plugin (fela-plugin-prefixer) instead. See https://github.com/rofrischmann/fela/tree/master/packages/fela-plugin-prefixer`)
+
 # fela-plugin-dynamic-prefixer
 
 <img alt="npm version" src="https://badge.fury.io/js/ffela-plugin-dynamic-prefixer.svg"> <img alt="npm downloads" src="https://img.shields.io/npm/dm/fela-plugin-dynamic-prefixer.svg">

--- a/packages/fela-plugin-dynamic-prefixer/src/deprecate.js
+++ b/packages/fela-plugin-dynamic-prefixer/src/deprecate.js
@@ -1,0 +1,8 @@
+const cache = {}
+
+export default function deprecate(message) {
+  if (process.env.NODE_ENV !== 'production' && !cache[message]) {
+    console.warn(message)
+    cache[message] = true
+  }
+}

--- a/packages/fela-plugin-dynamic-prefixer/src/index.js
+++ b/packages/fela-plugin-dynamic-prefixer/src/index.js
@@ -1,6 +1,12 @@
 /* @flow  */
 import Prefixer from 'inline-style-prefixer'
 
+import deprecate from './deprecate'
+
+deprecate(`The dynamic prefixer plugin (fela-plugin-dynamic-prefixer) is deprecated, please remove it from your Fela configuration.
+inline-style-prefixer will remove its dynamic version due to increasing issues with newer browers, browser detection and false prefixing.
+Use the static prefixer plugin (fela-plugin-prefixer) instead. See https://github.com/rofrischmann/fela/tree/master/packages/fela-plugin-prefixer`)
+
 export default function dynamicPrefixer(options: Object) {
   const prefixer = new Prefixer(options)
 


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guide-lines at the bottom.
------------------------------------------->

## Description
This PR deprecates fela-plugin-dynamic-prefixer as inline-style-prefixer will soon drop support for dynamic prefixing completely.
Using the static version (fela-plugin-prefixer) is recommended.

## Versioning
<!------------------------------------------
  Please add all updated packages and propose new versions following the semantic versioning guidelines
------------------------------------------->


#### Major

#### Minor

#### Patch
- fela-plugin-dynamic-prefixer

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [ ] Documentation has been added/updated
- [x] My changes have proper flow-types

## ToDo
- [ ] update documentation
- [ ] remove fela-plugin-dynamic-prefixer after merge
