### PR TITLE
Deprecate: fela-plugin-remove-undefined

### DIFF
--- a/packages/fela-plugin-remove-undefined/README.md
+++ b/packages/fela-plugin-remove-undefined/README.md
@@ -1,3 +1,5 @@
+> **Deprecated!**<br>The remove undefined plugin (fela-plugin-remove-undefined) is deprecated, please remove it from your Fela configuration.<br>Fela automatically removes 'undefined' values making this plugin obsolete.
+
 # fela-plugin-remove-undefined
 
 <img alt="npm version" src="https://badge.fury.io/js/fela-plugin-remove-undefined.svg"> <img alt="npm downloads" src="https://img.shields.io/npm/dm/fela-plugin-remove-undefined.svg">

--- a/packages/fela-plugin-remove-undefined/src/deprecate.js
+++ b/packages/fela-plugin-remove-undefined/src/deprecate.js
@@ -1,0 +1,8 @@
+const cache = {}
+
+export default function deprecate(message) {
+  if (process.env.NODE_ENV !== 'production' && !cache[message]) {
+    console.warn(message)
+    cache[message] = true
+  }
+}

--- a/packages/fela-plugin-remove-undefined/src/index.js
+++ b/packages/fela-plugin-remove-undefined/src/index.js
@@ -2,6 +2,11 @@
 import { isUndefinedValue } from 'fela-utils'
 import isPlainObject from 'isobject'
 
+import deprecate from './deprecate'
+
+deprecate(`The remove undefined plugin (fela-plugin-remove-undefined) is deprecated, please remove it from your Fela configuration.
+Fela automatically removes 'undefined' values making this plugin obsolete.`)
+
 function removeUndefined(style: Object): Object {
   for (const property in style) {
     const value = style[property]


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guide-lines at the bottom.
------------------------------------------->

## Description
This PR deprecates fela-plugin-remove-undefined as Fela automatically strips `undefined` values.

## Versioning
<!------------------------------------------
  Please add all updated packages and propose new versions following the semantic versioning guidelines
------------------------------------------->


#### Major

#### Minor

#### Patch
- fela-plugin-remove-undefined

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [ ] Documentation has been added/updated
- [x] My changes have proper flow-types

## ToDo
- [ ] update documentation
- [ ] remove fela-plugin-remove-undefined after merge
