### PR TITLE
add getDerivedStateFromProps to hoistStatics

### DIFF
--- a/packages/fela-bindings/src/hoistStatics.js
+++ b/packages/fela-bindings/src/hoistStatics.js
@@ -12,7 +12,11 @@ const basicStatics = {
 }
 
 const mergableStatics = ['contextTypes', 'defaultProps']
-const blockedStatics = { childContextTypes: true, propTypes: true }
+const blockedStatics = {
+  childContextTypes: true,
+  propTypes: true,
+  getDerivedStateFromProps: true,
+}
 
 export default function hoistStatics(target: any, source: any): any {
   if (typeof source === 'string') {


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guide-lines at the bottom.
------------------------------------------->

## Description
Adds `getDerivedStateFromProps` as a locked static to the `hoistStatic` ulitity in fela-bindings.

## Versioning
<!------------------------------------------
  Please add all updated packages and propose new versions following the semantic versioning guidelines
------------------------------------------->


#### Major

#### Minor

#### Patch
- fela-bindings

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

