### PR TITLE
Fix error `React.Children.only` for `Provider` in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ If you ever used [styled-components](https://www.styled-components.com), this wi
 > **Read**: [Usage with React](http://fela.js.org/docs/guides/UsageWithReact.html) for a full guide.
 
 ```javascript
+import { Fragment } from 'react';
 import { createComponent, Provider } from 'react-fela'
 import { render } from 'react-dom'
 
@@ -117,8 +118,10 @@ const Button = createComponent(rule, 'button')
 
 render(
   <Provider renderer={renderer}>
-    <Button primary>Primary</Button>
-    <Button>Default</Button>
+    <Fragment>
+      <Button primary>Primary</Button>
+      <Button>Default</Button>
+    </Fragment>
   </Provider>,
   document.body
 )


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guide-lines at the bottom.
------------------------------------------->

## Description
Error occuring when using code from example
http://s.csssr.ru/UAHCBP6MS/Fela_css-in-js_playground_-_Google_Chrome_2018-07-10_23.34.20.png

## Example
If required, add a code example or a link to a working example (repository).

```javascript
// your code 
```

## Versioning
<!------------------------------------------
  Please add all updated packages and propose new versions following the semantic versioning guidelines
------------------------------------------->


#### Major

#### Minor

#### Patch

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [ ] Tests have been added/updated
- [x] Documentation has been added/updated
- [ ] My changes have proper flow-types

