### PR TITLE
Fix remove undefined deprecation warning

### DIFF
--- a/packages/fela-plugin-extend/package.json
+++ b/packages/fela-plugin-extend/package.json
@@ -23,9 +23,8 @@
     "fela": "^6.1.7"
   },
   "dependencies": {
-    "css-in-js-utils": "^2.0.0",
     "fast-loops": "^1.0.0",
-    "fela-plugin-remove-undefined": "^5.0.21",
+    "fela-utils": "^8.0.8",
     "isobject": "^3.0.1"
   }
 }

--- a/packages/fela-plugin-extend/src/index.js
+++ b/packages/fela-plugin-extend/src/index.js
@@ -2,13 +2,23 @@
 import objectEach from 'fast-loops/lib/objectEach'
 import arrayEach from 'fast-loops/lib/arrayEach'
 import isPlainObject from 'isobject'
-import removeUndefinedPlugin from 'fela-plugin-remove-undefined'
+import { isUndefinedValue } from 'fela-utils'
 
 import type { StyleType } from '../../../flowtypes/StyleType'
 import type { DOMRenderer } from '../../../flowtypes/DOMRenderer'
 import type { NativeRenderer } from '../../../flowtypes/NativeRenderer'
 
-const removeUndefined = removeUndefinedPlugin()
+function removeUndefined(style: Object) {
+  objectEach(style, (value, key) => {
+    if (isPlainObject(value)) {
+      style[key] = removeUndefined(value)
+    } else if (Array.isArray(value)) {
+      style[key] = value.filter(val => !isUndefinedValue(val))
+    } else {
+      delete style[key]
+    }
+  })
+}
 
 function extendStyle(
   style: Object,

--- a/packages/fela-plugin-extend/yarn.lock
+++ b/packages/fela-plugin-extend/yarn.lock
@@ -13,6 +13,14 @@ fast-loops@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fast-loops/-/fast-loops-1.0.0.tgz#2cdd7e0ff67343b2b5f5e627d855a50b4bed559a"
 
+fela-utils@^8.0.8:
+  version "8.0.8"
+  resolved "https://registry.yarnpkg.com/fela-utils/-/fela-utils-8.0.8.tgz#1ffb7b7263df619a998ad3d04beac1be19027887"
+  dependencies:
+    css-in-js-utils "^2.0.0"
+    fast-loops "^1.0.0"
+    string-hash "^1.1.3"
+
 hyphenate-style-name@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz#31160a36930adaf1fc04c6074f7eb41465d4ec4b"
@@ -20,3 +28,7 @@ hyphenate-style-name@^1.0.2:
 isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
+
+string-hash@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/string-hash/-/string-hash-1.1.3.tgz#e8aafc0ac1855b4666929ed7dd1275df5d6c811b"


### PR DESCRIPTION
## Description

Fixes https://github.com/rofrischmann/fela/issues/584

## Quality Assurance

I followed the steps as laid out in the contributing guide (`yarn check`) and get 180 warnings about various packages "could not be deduped from x to y"  and I also get a couple of errors

```
error "react-native#react@16.0.0-alpha.12" doesn't satisfy found match of "react@15.6.2"
error "npmi#npm#semver" is wrong version: expected "5.1.1", got "5.1.0"
```

...but both these errors and all the warnings are dependency related which have nothing to do with the updates in this PR.
