### PR TITLE
Feature CSSType

### DIFF
--- a/packages/fela/index.d.ts
+++ b/packages/fela/index.d.ts
@@ -1,6 +1,6 @@
 declare module "fela" {
 
-  import { CSSProperties } from 'react';
+  import * as CSS from 'csstype';
 
   export type TRuleProps = {};
   export type TRule<T = TRuleProps> = (props: T) => IStyle
@@ -47,7 +47,7 @@ declare module "fela" {
     selectorPrefix?: string;
   }
 
-  export interface IStyle extends CSSProperties {
+  export interface IStyle extends CSS.Properties<string | number> {
     //TODO: add properties, missing in React.CSSProperties
   }
 

--- a/packages/fela/package.json
+++ b/packages/fela/package.json
@@ -32,6 +32,7 @@
   "license": "MIT",
   "dependencies": {
     "css-in-js-utils": "^2.0.0",
+    "csstype": "^2.5.5",
     "fast-loops": "^1.0.0",
     "fela-utils": "^8.0.8",
     "isobject": "^3.0.1"

--- a/packages/fela/yarn.lock
+++ b/packages/fela/yarn.lock
@@ -9,9 +9,39 @@ css-in-js-utils@^2.0.0:
     hyphenate-style-name "^1.0.2"
     isobject "^3.0.1"
 
+csstype@^2.5.5:
+  version "2.5.5"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.5.5.tgz#4125484a3d42189a863943f23b9e4b80fedfa106"
+
 fast-loops@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fast-loops/-/fast-loops-1.0.0.tgz#2cdd7e0ff67343b2b5f5e627d855a50b4bed559a"
+
+fela-tools@^5.1.7:
+  version "5.1.7"
+  resolved "https://registry.yarnpkg.com/fela-tools/-/fela-tools-5.1.7.tgz#114f3a086da1f90ae787c460b44303e3b6a280a8"
+  dependencies:
+    css-in-js-utils "^2.0.0"
+    fast-loops "^1.0.0"
+    fela "^6.1.9"
+    fela-utils "^8.0.8"
+
+fela-utils@^8.0.8:
+  version "8.0.8"
+  resolved "https://registry.yarnpkg.com/fela-utils/-/fela-utils-8.0.8.tgz#1ffb7b7263df619a998ad3d04beac1be19027887"
+  dependencies:
+    css-in-js-utils "^2.0.0"
+    fast-loops "^1.0.0"
+    string-hash "^1.1.3"
+
+fela@^6.1.9:
+  version "6.1.9"
+  resolved "https://registry.yarnpkg.com/fela/-/fela-6.1.9.tgz#9c79b69e796d3323da2adbabc04a98478789fc1a"
+  dependencies:
+    css-in-js-utils "^2.0.0"
+    fast-loops "^1.0.0"
+    fela-utils "^8.0.8"
+    isobject "^3.0.1"
 
 hyphenate-style-name@^1.0.2:
   version "1.0.2"
@@ -20,3 +50,7 @@ hyphenate-style-name@^1.0.2:
 isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
+
+string-hash@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/string-hash/-/string-hash-1.1.3.tgz#e8aafc0ac1855b4666929ed7dd1275df5d6c811b"


### PR DESCRIPTION
## Description

React's `CSSProperties` interface extends from CSSType's `Properties` interface in exactly the same way that I have done in this PR.

Using the typings from `csstype` rather than `react` means that projects that are using Fela _but not React_ don't have to add `react` as a dependency just to get CSS typings.
