### PR TITLE
Replace unallowed symbols in class name with underscore

### DIFF
--- a/packages/fela-bindings/src/__tests__/__snapshots__/createComponentFactory-test.js.snap
+++ b/packages/fela-bindings/src/__tests__/__snapshots__/createComponentFactory-test.js.snap
@@ -889,6 +889,48 @@ Array [
 ]
 `;
 
+exports[`Creating Components with a Proxy for props from Fela rules should replace rare unallowed symbols in className with underscore 1`] = `
+Array [
+  "<style>
+    .rule_1_______________abrv9k {
+        font-size: 16
+    }
+</style>",
+  <rule>
+    <rule
+        _felaTheme={Object {}}
+    >
+        <1!@#$%^&*{}/=\\
+            className="rule_1_______________abrv9k"
+        >
+            <div />
+        </1!@#$%^&*{}/=\\>
+    </rule>
+</rule>,
+]
+`;
+
+exports[`Creating Components with a Proxy for props from Fela rules should replace unallowed symbols in className with underscore 1`] = `
+Array [
+  "<style>
+    .rule_connect_Component___abrv9k {
+        font-size: 16
+    }
+</style>",
+  <rule>
+    <rule
+        _felaTheme={Object {}}
+    >
+        <connect(Component)
+            className="rule_connect_Component___abrv9k"
+        >
+            <div />
+        </connect(Component)>
+    </rule>
+</rule>,
+]
+`;
+
 exports[`Creating Components with a Proxy for props from Fela rules should use a dev-friendly className and the selectorPrefix 1`] = `
 Array [
   "<style>

--- a/packages/fela-bindings/src/__tests__/createComponentFactory-test.js
+++ b/packages/fela-bindings/src/__tests__/createComponentFactory-test.js
@@ -803,6 +803,64 @@ describe('Creating Components with a Proxy for props from Fela rules', () => {
     ]).toMatchSnapshot()
   })
 
+  it('should replace unallowed symbols in className with underscore', () => {
+    const rule = () => ({
+      fontSize: 16,
+    })
+
+    const Parent = () => React.createElement('div')
+    Parent.displayName = 'connect(Component)'
+    const Component = createComponent(rule, Parent)
+
+    const renderer = createRenderer({
+      enhancers: [
+        monolithic({
+          prettySelectors: true,
+        }),
+      ],
+    })
+
+    const wrapper = mount(<Component />, {
+      context: {
+        renderer,
+      },
+    })
+
+    expect([
+      beautify(`<style>${renderToString(renderer)}</style>`),
+      toJson(wrapper),
+    ]).toMatchSnapshot()
+  })
+
+  it('should replace rare unallowed symbols in className with underscore', () => {
+    const rule = () => ({
+      fontSize: 16,
+    })
+
+    const Parent = () => React.createElement('div')
+    Parent.displayName = '1!@#$%^&*{}/=\\'
+    const Component = createComponent(rule, Parent)
+
+    const renderer = createRenderer({
+      enhancers: [
+        monolithic({
+          prettySelectors: true,
+        }),
+      ],
+    })
+
+    const wrapper = mount(<Component />, {
+      context: {
+        renderer,
+      },
+    })
+
+    expect([
+      beautify(`<style>${renderToString(renderer)}</style>`),
+      toJson(wrapper),
+    ]).toMatchSnapshot()
+  })
+
   it('should pass props except innerRef', () => {
     const rule = props => ({
       color: props.color,

--- a/packages/fela-bindings/src/createComponentFactory.js
+++ b/packages/fela-bindings/src/createComponentFactory.js
@@ -58,8 +58,15 @@ export default function createComponentFactory(
 
       // improve developer experience with monolithic renderer
       if (process.env.NODE_ENV !== 'production' && renderer.prettySelectors) {
+        const replaceUnallowedSymbolsWithUnderscore = cn =>
+          cn.replace(/[^_a-z0-9-]/gi, '_')
+
         const componentName =
-          typeof type === 'string' ? type : type.displayName || type.name || ''
+          typeof type === 'string'
+            ? type
+            : replaceUnallowedSymbolsWithUnderscore(
+                type.displayName || type.name || ''
+              )
 
         combinedRule.selectorPrefix = `${displayName}_${componentName}_`
       }


### PR DESCRIPTION
Fixes #596

<!------------------------------------------
  Thanks for contributing!
  Please read the guide-lines at the bottom.
------------------------------------------->

## Description
Replace unallowed symbols with underscore for class names based on function `.name` or component `.displayName`.

I wanted to escape class names at first, but this approach has two downsides:
1. We need to add `css.escape` dependency to polyfill CSS.escape. It would be used for development only, but still
2. We need to escape it in style tag, but keep unescaped name in dom attribute. It adds extra troubles

## Versioning
<!------------------------------------------
  Please add all updated packages and propose new versions following the semantic versioning guidelines
------------------------------------------->

#### Patch

- fela-bindings
- react-fela
- preact-fela
- inferno-fela

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

