### PR TITLE
Handle exceptions extracting used props

### DIFF
--- a/packages/fela-bindings/src/__tests__/extractUsedProps-test.js
+++ b/packages/fela-bindings/src/__tests__/extractUsedProps-test.js
@@ -1,0 +1,19 @@
+import extractUsedProps from '../extractUsedProps'
+
+describe('Extracting used props', () => {
+  it('should return used props', () => {
+    expect(
+      extractUsedProps(props => {
+        props.foo, props.bar
+      })
+    ).toEqual(['foo', 'bar'])
+  })
+
+  it('should return an empty array if the rule throws an exception', () => {
+    expect(
+      extractUsedProps(props => {
+        throw new Error('test')
+      })
+    ).toEqual([])
+  })
+})

--- a/packages/fela-bindings/src/__tests__/extractUsedProps-test.js
+++ b/packages/fela-bindings/src/__tests__/extractUsedProps-test.js
@@ -3,15 +3,16 @@ import extractUsedProps from '../extractUsedProps'
 describe('Extracting used props', () => {
   it('should return used props', () => {
     expect(
-      extractUsedProps(props => {
-        props.foo, props.bar
-      })
+      extractUsedProps(props => ({
+        foo: props.foo,
+        bar: props.bar,
+      }))
     ).toEqual(['foo', 'bar'])
   })
 
   it('should return an empty array if the rule throws an exception', () => {
     expect(
-      extractUsedProps(props => {
+      extractUsedProps(() => {
         throw new Error('test')
       })
     ).toEqual([])

--- a/packages/fela-bindings/src/extractUsedProps.js
+++ b/packages/fela-bindings/src/extractUsedProps.js
@@ -24,6 +24,10 @@ export default function extractUsedProps(
   })
 
   const proxy = new Proxy({ theme }, handler(usedProps))
-  rule(proxy)
-  return usedProps
+  try {
+    rule(proxy)
+    return usedProps
+  } catch (err) {
+    return []
+  }
 }


### PR DESCRIPTION
Fix #595

<!------------------------------------------
  Thanks for contributing!
  Please read the guide-lines at the bottom.
------------------------------------------->

## Description
Add a try/catch in `extractUsedProps` when the rule is evaluated. If the rule throws an unhandled exception, returns an empty array.

#### Patch

* fela-bindings

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

