### PR TITLE
Fix statistics renderToString

### DIFF
--- a/packages/fela-statistics/src/index.js
+++ b/packages/fela-statistics/src/index.js
@@ -2,6 +2,7 @@
 /* eslint-disable prefer-rest-params */
 import gzipSize from 'gzip-size'
 import { RULE_TYPE } from 'fela-utils'
+import { renderToString } from 'fela-tools'
 
 import type DOMRenderer from '../../../flowtypes/DOMRenderer'
 
@@ -100,7 +101,7 @@ function addStatistics(
       number: reuse,
     }
 
-    const currentCSS = renderer.renderToString()
+    const currentCSS = renderToString(renderer)
     const bytes = lengthInUtf8Bytes(currentCSS)
 
     currentStats.size = {


### PR DESCRIPTION
## Description
The method `renderer.renderToString()` is no more available. Using fela-tools
to get the css string rendered for statistics.

## Versioning

#### Major

#### Minor

#### Patch
fela-statistics

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`) (not due to my changes)
- [x] All tests are passing (`yarn run test`)  (a lots are failing, but not because of statistics package)
- [x] There are no flow-type errors (`yarn run flow`) (not in statistics package)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated (there were no tests for statistics)
- [x] Documentation has been added/updated (nothing changed
- [x] My changes have proper flow-types (nothing changed)

