### PR TITLE
Update ProviderProps in index.d.ts

### DIFF
--- a/packages/fela/index.d.ts
+++ b/packages/fela/index.d.ts
@@ -319,7 +319,7 @@ declare module "react-fela" {
 
   interface ProviderProps {
     renderer: object;
-    mountNode?: any;
+    rehydrate: boolean;
   }
 
   interface FelaWithThemeProps<Theme> {


### PR DESCRIPTION
## Description
`ProviderProps` did not match what `Provider` was actually expecting. This PR updates the definition of `ProviderProps` to remove `mountNode` and add `rehydrate`.