### PR TITLE
Conditional Rehydration for nullable sheets

### DIFF
--- a/packages/fela-dom/src/dom/rehydrate.js
+++ b/packages/fela-dom/src/dom/rehydrate.js
@@ -49,16 +49,21 @@ export default function rehydrate(renderer: DOMRenderer): void {
           rehydrateRules(css, media, '', renderer.cache)
         }
 
-        arrayEach(node.sheet.cssRules, rule => {
-          const selectorText = rule.conditionText
-            ? rule.cssRules[0].selectorText
-            : rule.selectorText
+        // On Safari, style sheets with IE-specific media queries
+        // can yield null for node.sheet
+        // https://github.com/rofrischmann/fela/issues/431#issuecomment-423239591
+        if (node.sheet && node.sheet.cssRules) {
+          arrayEach(node.sheet.cssRules, rule => {
+            const selectorText = rule.conditionText
+              ? rule.cssRules[0].selectorText
+              : rule.selectorText
 
-          rule.score = getRuleScore(
-            renderer.ruleOrder,
-            selectorText.split(CLASSNAME_REGEX)[1]
-          )
-        })
+            rule.score = getRuleScore(
+              renderer.ruleOrder,
+              selectorText.split(CLASSNAME_REGEX)[1]
+            )
+          })
+        }
       }
     }
   })


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guide-lines at the bottom.
------------------------------------------->

## Description
Fixes a bug for Safari 12 where rehydrated sheets yield null when using IE-specific media queries.

## Versioning
<!------------------------------------------
  Please add all updated packages and propose new versions following the semantic versioning guidelines
------------------------------------------->


#### Major

#### Minor

#### Patch
- fela-dom

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

