### PR TITLE
Stop leaking composed passThroughProps with createComponentWithProxy

### DIFF
--- a/packages/fela-bindings/src/__tests__/__snapshots__/createComponentFactory-test.js.snap
+++ b/packages/fela-bindings/src/__tests__/__snapshots__/createComponentFactory-test.js.snap
@@ -42,8 +42,16 @@ Array [
         onClick={[Function]}
     >
         <FelaComponent
+            _felaProps={
+                Object {
+                    "as": undefined,
+                    "color": "red",
+                    "id": undefined,
+                    "onClick": [Function],
+                    "theme": Object {},
+                  }
+            }
             _felaRule={[Function]}
-            color="red"
             onClick={[Function]}
             passThrough={
                 Array [
@@ -52,9 +60,17 @@ Array [
             }
         >
             <FelaComponent
+                _felaProps={
+                    Object {
+                        "as": undefined,
+                        "color": "red",
+                        "id": undefined,
+                        "onClick": [Function],
+                        "theme": Object {},
+                      }
+                }
                 _felaRule={[Function]}
                 _felaTheme={Object {}}
-                color="red"
                 onClick={[Function]}
                 passThrough={
                     Array [
@@ -64,7 +80,6 @@ Array [
             >
                 <div
                     className=""
-                    color="red"
                     onClick={[Function]}
                 />
             </FelaComponent>
@@ -94,10 +109,24 @@ Array [
         _felaTheme={Object {}}
     >
         <rule
+            _felaProps={
+                Object {
+                    "as": undefined,
+                    "id": undefined,
+                    "theme": Object {},
+                  }
+            }
             _felaRule={[Function]}
             passThrough={Array []}
         >
             <rule
+                _felaProps={
+                    Object {
+                        "as": undefined,
+                        "id": undefined,
+                        "theme": Object {},
+                      }
+                }
                 _felaRule={[Function]}
                 _felaTheme={Object {}}
                 passThrough={Array []}
@@ -459,16 +488,30 @@ Array [
         color="green"
     >
         <rule
+            _felaProps={
+                Object {
+                    "as": "i",
+                    "color": "green",
+                    "id": undefined,
+                    "theme": Object {},
+                  }
+            }
             _felaRule={[Function]}
             as="i"
-            color="green"
             passThrough={Array []}
         >
             <rule
+                _felaProps={
+                    Object {
+                        "as": "i",
+                        "color": "green",
+                        "id": undefined,
+                        "theme": Object {},
+                      }
+                }
                 _felaRule={[Function]}
                 _felaTheme={Object {}}
                 as="i"
-                color="green"
                 passThrough={Array []}
             >
                 <i
@@ -614,6 +657,15 @@ Array [
         onClick={[Function]}
     >
         <FelaComponent
+            _felaProps={
+                Object {
+                    "as": undefined,
+                    "color": "red",
+                    "id": undefined,
+                    "onClick": [Function],
+                    "theme": Object {},
+                  }
+            }
             _felaRule={[Function]}
             color="red"
             onClick={[Function]}
@@ -626,6 +678,15 @@ Array [
             }
         >
             <FelaComponent
+                _felaProps={
+                    Object {
+                        "as": undefined,
+                        "color": "red",
+                        "id": undefined,
+                        "onClick": [Function],
+                        "theme": Object {},
+                      }
+                }
                 _felaRule={[Function]}
                 _felaTheme={Object {}}
                 color="red"
@@ -670,10 +731,24 @@ Array [
         _felaTheme={Object {}}
     >
         <rule
+            _felaProps={
+                Object {
+                    "as": undefined,
+                    "id": undefined,
+                    "theme": Object {},
+                  }
+            }
             _felaRule={[Function]}
             passThrough={Array []}
         >
             <rule
+                _felaProps={
+                    Object {
+                        "as": undefined,
+                        "id": undefined,
+                        "theme": Object {},
+                      }
+                }
                 _felaRule={[Function]}
                 _felaTheme={Object {}}
                 passThrough={Array []}
@@ -685,6 +760,116 @@ Array [
         </rule>
     </anotherRule>
 </anotherRule>,
+]
+`;
+
+exports[`Creating Components with a Proxy for props from Fela rules should not leak passed through props 1`] = `
+Array [
+  "<style>
+    .a {
+        border: none
+    }
+
+    .b {
+        background-color: red
+    }
+
+    .c {
+        color: red
+    }
+</style>",
+  <FelaComponent
+    color="red"
+>
+    <FelaComponent
+        _felaTheme={Object {}}
+        color="red"
+    >
+        <FelaComponent
+            _felaProps={
+                Object {
+                    "as": undefined,
+                    "color": "red",
+                    "id": undefined,
+                    "theme": Object {},
+                  }
+            }
+            _felaRule={[Function]}
+            passThrough={Array []}
+        >
+            <FelaComponent
+                _felaProps={
+                    Object {
+                        "as": undefined,
+                        "color": "red",
+                        "id": undefined,
+                        "theme": Object {},
+                      }
+                }
+                _felaRule={[Function]}
+                _felaTheme={Object {}}
+                passThrough={Array []}
+            >
+                <button
+                    className="a b c"
+                />
+            </FelaComponent>
+        </FelaComponent>
+    </FelaComponent>
+</FelaComponent>,
+]
+`;
+
+exports[`Creating Components with a Proxy for props from Fela rules should not leak unused through props 1`] = `
+Array [
+  "<style>
+    .a {
+        border: none
+    }
+
+    .b {
+        color: red
+    }
+</style>",
+  <FelaComponent
+    color="red"
+>
+    <FelaComponent
+        _felaTheme={Object {}}
+        color="red"
+    >
+        <FelaComponent
+            _felaProps={
+                Object {
+                    "as": undefined,
+                    "color": "red",
+                    "id": undefined,
+                    "theme": Object {},
+                  }
+            }
+            _felaRule={[Function]}
+            passThrough={Array []}
+        >
+            <FelaComponent
+                _felaProps={
+                    Object {
+                        "as": undefined,
+                        "color": "red",
+                        "id": undefined,
+                        "theme": Object {},
+                      }
+                }
+                _felaRule={[Function]}
+                _felaTheme={Object {}}
+                passThrough={Array []}
+            >
+                <button
+                    className="a b"
+                />
+            </FelaComponent>
+        </FelaComponent>
+    </FelaComponent>
+</FelaComponent>,
 ]
 `;
 

--- a/packages/fela-bindings/src/__tests__/createComponentFactory-test.js
+++ b/packages/fela-bindings/src/__tests__/createComponentFactory-test.js
@@ -504,6 +504,65 @@ describe('Creating Components from Fela rules', () => {
 })
 
 describe('Creating Components with a Proxy for props from Fela rules', () => {
+  it('should not leak passed through props', () => {
+    const BorderlessButton = createComponentWithProxy(
+      ({ color }) => ({
+        border: 'none',
+        backgroundColor: color,
+      }),
+      'button'
+    )
+
+    const ColoredButton = createComponent(
+      ({ color }) => ({
+        color,
+      }),
+      BorderlessButton
+    )
+
+    const renderer = createRenderer()
+
+    const wrapper = mount(<ColoredButton color="red" />, {
+      context: {
+        renderer,
+      },
+    })
+
+    expect([
+      beautify(`<style>${renderToString(renderer)}</style>`),
+      toJson(wrapper),
+    ]).toMatchSnapshot()
+  })
+
+  it('should not leak unused through props', () => {
+    const BorderlessButton = createComponentWithProxy(
+      () => ({
+        border: 'none',
+      }),
+      'button'
+    )
+
+    const ColoredButton = createComponent(
+      ({ color }) => ({
+        color,
+      }),
+      BorderlessButton
+    )
+
+    const renderer = createRenderer()
+
+    const wrapper = mount(<ColoredButton color="red" />, {
+      context: {
+        renderer,
+      },
+    })
+
+    expect([
+      beautify(`<style>${renderToString(renderer)}</style>`),
+      toJson(wrapper),
+    ]).toMatchSnapshot()
+  })
+
   it('should return a Component', () => {
     const rule = props => ({
       color: props.color,

--- a/packages/fela-bindings/src/createComponentFactory.js
+++ b/packages/fela-bindings/src/createComponentFactory.js
@@ -26,6 +26,7 @@ export default function createComponentFactory(
         children,
         _felaTheme,
         _felaRule,
+        _felaProps = {},
         extend,
         innerRef,
         id,
@@ -74,16 +75,22 @@ export default function createComponentFactory(
       const resolvedPassThrough = [
         ...alwaysPassThroughProps,
         ...resolvePassThrough(passThroughProps, otherProps),
-        ...resolvePassThrough(passThrough, otherProps),
+        ...(withProxy ? [] : resolvePassThrough(passThrough, otherProps)),
         ...(withProxy ? resolveUsedProps(usedProps, otherProps) : []),
       ]
 
       const ruleProps = {
+        ..._felaProps,
         ...otherProps,
         theme: _felaTheme,
         as,
         id,
       }
+
+      const componentProps = extractPassThroughProps(
+        resolvedPassThrough,
+        otherProps
+      )
 
       // if the component renders into another Fela component
       // we pass down the combinedRule as well as both
@@ -92,22 +99,18 @@ export default function createComponentFactory(
           type,
           {
             _felaRule: combinedRule,
+            _felaProps: ruleProps,
             passThrough: resolvedPassThrough,
             innerRef,
             style,
             className,
             as,
             id,
-            ...otherProps,
+            ...componentProps,
           },
           children
         )
       }
-
-      const componentProps = extractPassThroughProps(
-        resolvedPassThrough,
-        otherProps
-      )
 
       // fela-native support
       if (renderer.isNativeRenderer) {


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guide-lines at the bottom.
------------------------------------------->

## Description
This will fix a common issue when composing components created with `createComponentWithProxy` (https://github.com/rofrischmann/fela/issues/538)

## Example
If required, add a code example or a link to a working example (repository).

```javascript
const BorderlessButton = createComponentWithProxy(() => ({
  border: 'none'
}), 'button');

const ColoredButton = createComponent(({color}) => ({
  color
}), BorderlessButton);

render(
  <ColoredButton color="red" />
);
```

will now yield 
```HTML
<button class="a b"></button>
```

rather than
```HTML
<button color="red" class="a b"></button>
```

## Problem

The problem is, with this the following won't work either:
```js
const ColoredButton = createComponent(({color}) => ({
  color
}), BorderlessButton, ['color']);
```
because `createComponentWithProxy` will ignore composed passThroughProps.

## Versioning
<!------------------------------------------
  Please add all updated packages and propose new versions following the semantic versioning guidelines
------------------------------------------->


#### Major

#### Minor

#### Patch
* fela-bindings

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [ ] The code was formatted using Prettier (`yarn run format`)
- [ ] The code has no linting errors (`yarn run lint`)
- [ ] All tests are passing (`yarn run test`) 
- [ ] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [ ] Tests have been added/updated
- [ ] Documentation has been added/updated
- [ ] My changes have proper flow-types