### PR TITLE
Deprecate fela-combine-arrays

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
         "beautify": "^0.0.8",
         "codeclimate-test-reporter": "^0.3.1",
         "cross-env": "^1.0.8",
-        "css-in-js-utils": "^2.0.0",
+        "css-in-js-utils": "^3.0.0",
         "enzyme": "2.8.2",
         "enzyme-to-json": "1.5.1",
         "eslint": "^3.14.0",

--- a/packages/fela-bindings/src/__tests__/__snapshots__/feFactory-test.js.snap
+++ b/packages/fela-bindings/src/__tests__/__snapshots__/feFactory-test.js.snap
@@ -13,7 +13,6 @@ Array [
     renderer={
         Object {
             "_emitChange": [Function],
-            "_mergeStyle": [Function],
             "_renderStyle": [Function],
             "_renderStyleToClassNames": [Function],
             "cache": Object {
@@ -110,7 +109,6 @@ Array [
     renderer={
         Object {
             "_emitChange": [Function],
-            "_mergeStyle": [Function],
             "_renderStyle": [Function],
             "_renderStyleToClassNames": [Function],
             "cache": Object {

--- a/packages/fela-combine-arrays/README.md
+++ b/packages/fela-combine-arrays/README.md
@@ -1,5 +1,7 @@
 # fela-combine-arrays
 
+> Deprecated!<br>The combine arrays enhancer is deprecated, please remove it from your Fela configuration.<br>It is obsolete as [css-in-js-utils](https://github.com/rofrischmann/css-in-js-utils)' [assignStyle](https://github.com/rofrischmann/css-in-js-utils#assignstylebase-extend) now combines arrays by default.
+
 <img alt="npm version" src="https://badge.fury.io/js/fela-combine-arrays.svg"> <img alt="npm downloads" src="https://img.shields.io/npm/dm/fela-combine-arrays.svg">
 
 Enables merging array values when combining rules.<br>

--- a/packages/fela-combine-arrays/package.json
+++ b/packages/fela-combine-arrays/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fela-combine-arrays",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Fela enhancer to merge array values when combining rules",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/packages/fela-combine-arrays/src/deprecate.js
+++ b/packages/fela-combine-arrays/src/deprecate.js
@@ -1,0 +1,8 @@
+const cache = {}
+
+export default function deprecate(message) {
+  if (process.env.NODE_ENV !== 'production' && !cache[message]) {
+    console.warn(message)
+    cache[message] = true
+  }
+}

--- a/packages/fela-combine-arrays/src/index.js
+++ b/packages/fela-combine-arrays/src/index.js
@@ -4,7 +4,12 @@ import createMergeArrayStyle from './createMergeArrayStyle'
 import type DOMRenderer from '../../../flowtypes/DOMRenderer'
 import type NativeRenderer from '../../../flowtypes/NativeRenderer'
 
+import deprecate from './deprecate'
+
 type Renderer = DOMRenderer | NativeRenderer
+
+deprecate(`The combine arrays enhancer (fela-combine-arrays) is deprecated, please remove it from your Fela configuration.
+It is obsolete as css-in-js-utils' new 'assignStyle' implementation combines arrays by default. See https://github.com/rofrischmann/css-in-js-utils/pull/6`)
 
 export default function combineArrays(properties?: Array<string>) {
   const mergeStyle = createMergeArrayStyle(properties)

--- a/packages/fela-dom/package.json
+++ b/packages/fela-dom/package.json
@@ -23,7 +23,7 @@
   "author": "Robin Frischmann",
   "license": "MIT",
   "dependencies": {
-    "css-in-js-utils": "^2.0.0",
+    "css-in-js-utils": "^3.0.0",
     "fast-loops": "^1.0.1",
     "fela-utils": "^8.1.1"
   },

--- a/packages/fela-dom/yarn.lock
+++ b/packages/fela-dom/yarn.lock
@@ -2,12 +2,11 @@
 # yarn lockfile v1
 
 
-css-in-js-utils@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz#3b472b398787291b47cfe3e44fecfdd9e914ba99"
+css-in-js-utils@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-3.0.0.tgz#4379185f5cc79f9eba39b4e795c317f253ffaa40"
   dependencies:
     hyphenate-style-name "^1.0.2"
-    isobject "^3.0.1"
 
 fast-loops@^1.0.1:
   version "1.0.1"
@@ -16,7 +15,3 @@ fast-loops@^1.0.1:
 hyphenate-style-name@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz#31160a36930adaf1fc04c6074f7eb41465d4ec4b"
-
-isobject@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"

--- a/packages/fela-monolithic/package.json
+++ b/packages/fela-monolithic/package.json
@@ -23,7 +23,7 @@
   "author": "Robin Frischmann",
   "license": "MIT",
   "dependencies": {
-    "css-in-js-utils": "^2.0.0",
+    "css-in-js-utils": "^3.0.0",
     "fast-loops": "^1.0.0",
     "fela-utils": "^8.1.1",
     "isobject": "^3.0.1"

--- a/packages/fela-monolithic/yarn.lock
+++ b/packages/fela-monolithic/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-css-in-js-utils@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-2.0.0.tgz#5af1dd70f4b06b331f48d22a3d86e0786c0b9435"
+css-in-js-utils@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-3.0.0.tgz#4379185f5cc79f9eba39b4e795c317f253ffaa40"
   dependencies:
     hyphenate-style-name "^1.0.2"
 

--- a/packages/fela-native/src/index.js
+++ b/packages/fela-native/src/index.js
@@ -3,7 +3,6 @@ import { StyleSheet } from 'react-native'
 /* @flow */
 import arrayEach from 'fast-loops/lib/arrayEach'
 import { processStyleWithPlugins, RULE_TYPE, CLEAR_TYPE } from 'fela-utils'
-import assignStyle from 'css-in-js-utils/lib/assignStyle'
 
 import type {
   NativeRenderer,
@@ -59,8 +58,6 @@ export function createRenderer(
 
       return renderer.cache[reference].style
     },
-
-    _mergeStyle: assignStyle,
 
     _emitChange(change: Object): void {
       arrayEach(renderer.listeners, listener => listener(change))

--- a/packages/fela-plugin-custom-property/package.json
+++ b/packages/fela-plugin-custom-property/package.json
@@ -22,7 +22,7 @@
   "author": "Robin Frischmann",
   "license": "MIT",
   "dependencies": {
-    "css-in-js-utils": "^2.1.0",
+    "css-in-js-utils": "^3.0.0",
     "isobject": "^3.0.1"
   },
   "peerDependencies": {

--- a/packages/fela-plugin-custom-property/package.json
+++ b/packages/fela-plugin-custom-property/package.json
@@ -22,6 +22,7 @@
   "author": "Robin Frischmann",
   "license": "MIT",
   "dependencies": {
+    "css-in-js-utils": "^2.1.0",
     "isobject": "^3.0.1"
   },
   "peerDependencies": {

--- a/packages/fela-plugin-custom-property/src/__tests__/customProperty-test.js
+++ b/packages/fela-plugin-custom-property/src/__tests__/customProperty-test.js
@@ -38,9 +38,7 @@ describe('Custom property plugin', () => {
       },
     }
 
-    expect(
-      customProperty({ position })(style, 'RULE_TYPE', rendererMock)
-    ).toEqual({
+    expect(customProperty({ position })(style)).toEqual({
       width: 20,
       onHover: {
         top: 0,
@@ -58,9 +56,7 @@ describe('Custom property plugin', () => {
       padding: '1em',
     }
 
-    expect(
-      customProperty({ padding })(style, 'RULE_TYPE', rendererMock)
-    ).toEqual({
+    expect(customProperty({ padding })(style)).toEqual({
       padding: '1em',
     })
   })
@@ -78,7 +74,7 @@ describe('Custom property plugin', () => {
 
           return obj
         },
-      })({ padding: { l: '1px' } }, 'RULE_TYPE', rendererMock)
+      })({ padding: { l: '1px' } })
     ).toEqual({ paddingLeft: '1px' })
   })
 })

--- a/packages/fela-plugin-custom-property/src/__tests__/customProperty-test.js
+++ b/packages/fela-plugin-custom-property/src/__tests__/customProperty-test.js
@@ -1,9 +1,5 @@
 import customProperty from '../index'
 
-const rendererMock = {
-  _mergeStyle: Object.assign,
-}
-
 describe('Custom property plugin', () => {
   it('should resolve custom properties', () => {
     const position = positions => ({
@@ -18,9 +14,7 @@ describe('Custom property plugin', () => {
       position: [0, 20, 50, 20],
     }
 
-    expect(
-      customProperty({ position })(style, 'RULE_TYPE', rendererMock)
-    ).toEqual({
+    expect(customProperty({ position })(style)).toEqual({
       width: 20,
       top: 0,
       right: 20,

--- a/packages/fela-plugin-custom-property/src/index.js
+++ b/packages/fela-plugin-custom-property/src/index.js
@@ -1,21 +1,14 @@
 /* @flow */
 import isPlainObject from 'isobject'
+import assignStyle from 'css-in-js-utils/lib/assignStyle'
 
-import type { StyleType } from '../../../flowtypes/StyleType'
-import type { DOMRenderer } from '../../../flowtypes/DOMRenderer'
-import type { NativeRenderer } from '../../../flowtypes/NativeRenderer'
-
-function resolveCustomProperty(
-  style: Object,
-  properties: Object,
-  renderer: DOMRenderer | NativeRenderer
-): Object {
+function resolveCustomProperty(style: Object, properties: Object): Object {
   for (const property in style) {
     const value = style[property]
 
     if (properties.hasOwnProperty(property)) {
       const resolved = properties[property](value)
-      renderer._mergeStyle(style, resolved)
+      assignStyle(style, resolved)
 
       if (!resolved.hasOwnProperty(property)) {
         delete style[property]
@@ -23,7 +16,7 @@ function resolveCustomProperty(
     }
 
     if (style.hasOwnProperty(property) && isPlainObject(value)) {
-      style[property] = resolveCustomProperty(value, properties, renderer)
+      style[property] = resolveCustomProperty(value, properties)
     }
   }
 
@@ -31,9 +24,5 @@ function resolveCustomProperty(
 }
 
 export default function customProperty(properties: Object) {
-  return (
-    style: Object,
-    type: StyleType,
-    renderer: DOMRenderer | NativeRenderer
-  ) => resolveCustomProperty(style, properties, renderer)
+  return (style: Object) => resolveCustomProperty(style, properties)
 }

--- a/packages/fela-plugin-custom-property/yarn.lock
+++ b/packages/fela-plugin-custom-property/yarn.lock
@@ -2,6 +2,16 @@
 # yarn lockfile v1
 
 
+css-in-js-utils@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-3.0.0.tgz#4379185f5cc79f9eba39b4e795c317f253ffaa40"
+  dependencies:
+    hyphenate-style-name "^1.0.2"
+
+hyphenate-style-name@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz#31160a36930adaf1fc04c6074f7eb41465d4ec4b"
+
 isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"

--- a/packages/fela-plugin-extend/package.json
+++ b/packages/fela-plugin-extend/package.json
@@ -23,7 +23,7 @@
     "fela": "^6.1.7"
   },
   "dependencies": {
-    "css-in-js-utils": "^2.1.0",
+    "css-in-js-utils": "^3.0.0",
     "fast-loops": "^1.0.0",
     "fela-utils": "^8.1.1",
     "isobject": "^3.0.1"

--- a/packages/fela-plugin-extend/package.json
+++ b/packages/fela-plugin-extend/package.json
@@ -23,6 +23,7 @@
     "fela": "^6.1.7"
   },
   "dependencies": {
+    "css-in-js-utils": "^2.1.0",
     "fast-loops": "^1.0.0",
     "fela-utils": "^8.1.1",
     "isobject": "^3.0.1"

--- a/packages/fela-plugin-extend/src/__tests__/extend-test.js
+++ b/packages/fela-plugin-extend/src/__tests__/extend-test.js
@@ -1,9 +1,5 @@
 import extend from '../index'
 
-const rendererMock = {
-  _mergeStyle: Object.assign,
-}
-
 describe('Extend plugin', () => {
   it('should extend style objects', () => {
     const extension = {
@@ -14,7 +10,7 @@ describe('Extend plugin', () => {
       extend: extension,
     }
 
-    expect(extend()(base, 'RULE_TYPE', rendererMock)).toEqual({
+    expect(extend()(base)).toEqual({
       color: 'blue',
       backgroundColor: 'blue',
     })
@@ -32,7 +28,7 @@ describe('Extend plugin', () => {
       },
     }
 
-    expect(extend()(base, 'RULE_TYPE', rendererMock)).toEqual({
+    expect(extend()(base)).toEqual({
       color: 'blue',
       ':hover': {
         color: 'red',
@@ -53,7 +49,7 @@ describe('Extend plugin', () => {
       },
     }
 
-    expect(extend()(base, 'RULE_TYPE', rendererMock)).toEqual({
+    expect(extend()(base)).toEqual({
       color: 'blue',
       backgroundColor: 'blue',
     })
@@ -71,7 +67,7 @@ describe('Extend plugin', () => {
       },
     }
 
-    expect(extend()(base, 'RULE_TYPE', rendererMock)).toEqual({
+    expect(extend()(base)).toEqual({
       color: 'blue',
     })
   })
@@ -89,7 +85,7 @@ describe('Extend plugin', () => {
       extend: [extension, otherExtension],
     }
 
-    expect(extend()(base, 'RULE_TYPE', rendererMock)).toEqual({
+    expect(extend()(base)).toEqual({
       color: 'blue',
       backgroundColor: 'blue',
       fontSize: '12px',
@@ -115,7 +111,7 @@ describe('Extend plugin', () => {
       ],
     }
 
-    expect(extend()(base, 'RULE_TYPE', rendererMock)).toEqual({
+    expect(extend()(base)).toEqual({
       color: 'blue',
       backgroundColor: 'blue',
       fontSize: '12px',
@@ -141,7 +137,7 @@ describe('Extend plugin', () => {
       ],
     }
 
-    expect(extend()(base, 'RULE_TYPE', rendererMock)).toEqual({
+    expect(extend()(base)).toEqual({
       color: 'blue',
       backgroundColor: 'blue',
     })
@@ -155,7 +151,7 @@ describe('Extend plugin', () => {
       },
     }
 
-    expect(extend()(base, 'RULE_TYPE', rendererMock)).toEqual({
+    expect(extend()(base)).toEqual({
       color: 'blue',
     })
   })
@@ -170,7 +166,7 @@ describe('Extend plugin', () => {
       },
     }
 
-    expect(extend()(base, 'RULE_TYPE', rendererMock)).toEqual({
+    expect(extend()(base)).toEqual({
       color: 'blue',
       backgroundColor: 'red',
     })

--- a/packages/fela-plugin-extend/src/index.js
+++ b/packages/fela-plugin-extend/src/index.js
@@ -1,12 +1,10 @@
 /* @flow */
 import objectEach from 'fast-loops/lib/objectEach'
 import arrayEach from 'fast-loops/lib/arrayEach'
+import assignStyle from 'css-in-js-utils/lib/assignStyle'
 import isPlainObject from 'isobject'
-import { isUndefinedValue } from 'fela-utils'
 
-import type { StyleType } from '../../../flowtypes/StyleType'
-import type { DOMRenderer } from '../../../flowtypes/DOMRenderer'
-import type { NativeRenderer } from '../../../flowtypes/NativeRenderer'
+import { isUndefinedValue } from 'fela-utils'
 
 function removeUndefined(style: Object) {
   objectEach(style, (value, key) => {
@@ -21,40 +19,28 @@ function removeUndefined(style: Object) {
   return style
 }
 
-function extendStyle(
-  style: Object,
-  extension: Object,
-  extendPlugin: Function,
-  type: StyleType,
-  renderer: DOMRenderer | NativeRenderer
-): void {
+function extendStyle(style: Object, extension: Object): void {
   // extend conditional style objects
   if (extension.hasOwnProperty('condition')) {
     if (extension.condition) {
-      renderer._mergeStyle(style, extendPlugin(extension.style, type, renderer))
+      assignStyle(style, extend(extension.style))
     }
   } else {
     // extend basic style objects
-    renderer._mergeStyle(style, removeUndefined(extension))
+    assignStyle(style, removeUndefined(extension))
   }
 }
 
-function extend(
-  style: Object,
-  type: StyleType,
-  renderer: DOMRenderer | NativeRenderer
-): Object {
+function extend(style: Object): Object {
   objectEach(style, (value, property) => {
     if (property === 'extend') {
       const extensions = [].concat(value)
 
-      arrayEach(extensions, extension =>
-        extendStyle(style, extension, extend, type, renderer)
-      )
+      arrayEach(extensions, extension => extendStyle(style, extension))
       delete style[property]
     } else if (isPlainObject(value)) {
       // support nested extend as well
-      style[property] = extend(value, type, renderer)
+      style[property] = extend(value)
     }
   })
 

--- a/packages/fela-plugin-extend/yarn.lock
+++ b/packages/fela-plugin-extend/yarn.lock
@@ -2,9 +2,19 @@
 # yarn lockfile v1
 
 
+css-in-js-utils@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-3.0.0.tgz#4379185f5cc79f9eba39b4e795c317f253ffaa40"
+  dependencies:
+    hyphenate-style-name "^1.0.2"
+
 fast-loops@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fast-loops/-/fast-loops-1.0.0.tgz#2cdd7e0ff67343b2b5f5e627d855a50b4bed559a"
+
+hyphenate-style-name@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz#31160a36930adaf1fc04c6074f7eb41465d4ec4b"
 
 isobject@^3.0.1:
   version "3.0.1"

--- a/packages/fela-plugin-fallback-value/package.json
+++ b/packages/fela-plugin-fallback-value/package.json
@@ -21,7 +21,7 @@
   "author": "Robin Frischmann",
   "license": "MIT",
   "dependencies": {
-    "css-in-js-utils": "^2.0.0",
+    "css-in-js-utils": "^3.0.0",
     "isobject": "^3.0.1"
   }
 }

--- a/packages/fela-plugin-fallback-value/yarn.lock
+++ b/packages/fela-plugin-fallback-value/yarn.lock
@@ -2,12 +2,11 @@
 # yarn lockfile v1
 
 
-css-in-js-utils@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz#3b472b398787291b47cfe3e44fecfdd9e914ba99"
+css-in-js-utils@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-3.0.0.tgz#4379185f5cc79f9eba39b4e795c317f253ffaa40"
   dependencies:
     hyphenate-style-name "^1.0.2"
-    isobject "^3.0.1"
 
 hyphenate-style-name@^1.0.2:
   version "1.0.2"

--- a/packages/fela-plugin-native-media-query/package.json
+++ b/packages/fela-plugin-native-media-query/package.json
@@ -27,7 +27,7 @@
     "react-native": "*"
   },
   "dependencies": {
-    "css-in-js-utils": "^2.1.0",
+    "css-in-js-utils": "^3.0.0",
     "css-mediaquery": "^0.1.2",
     "fela-utils": "^8.1.1",
     "isobject": "^3.0.1"

--- a/packages/fela-plugin-native-media-query/package.json
+++ b/packages/fela-plugin-native-media-query/package.json
@@ -27,7 +27,7 @@
     "react-native": "*"
   },
   "dependencies": {
-    "css-in-js-utils": "^2.0.0",
+    "css-in-js-utils": "^2.1.0",
     "css-mediaquery": "^0.1.2",
     "fela-utils": "^8.1.1",
     "isobject": "^3.0.1"

--- a/packages/fela-plugin-native-media-query/src/index.js
+++ b/packages/fela-plugin-native-media-query/src/index.js
@@ -5,11 +5,9 @@ import { Dimensions } from 'react-native'
 import isPlainObject from 'isobject'
 import { match } from 'css-mediaquery'
 import { isMediaQuery } from 'fela-utils'
+import assignStyle from 'css-in-js-utils/lib/assignStyle'
 
 import DimensionProvider from './components/DimensionProvider'
-
-import type { StyleType } from '../../../flowtypes/StyleType'
-import type { NativeRenderer } from '../../../flowtypes/NativeRenderer'
 
 type Orientation = 'landscape' | 'portrait'
 
@@ -17,12 +15,9 @@ function getOrientation(width: number, height: number): Orientation {
   return width > height ? 'landscape' : 'portrait'
 }
 
-function resolveMediaQuery(
-  style: Object,
-  type: StyleType,
-  renderer: NativeRenderer
-): Object {
+function resolveMediaQuery(style: Object): Object {
   const { width, height } = Dimensions.get('window')
+
   for (const property in style) {
     const value = style[property]
 
@@ -35,7 +30,7 @@ function resolveMediaQuery(
           height,
         })
       ) {
-        renderer._mergeStyle(style, value)
+        assignStyle(style, value)
       }
 
       delete style[property]

--- a/packages/fela-plugin-native-media-query/yarn.lock
+++ b/packages/fela-plugin-native-media-query/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-css-in-js-utils@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-2.0.0.tgz#5af1dd70f4b06b331f48d22a3d86e0786c0b9435"
+css-in-js-utils@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-3.0.0.tgz#4379185f5cc79f9eba39b4e795c317f253ffaa40"
   dependencies:
     hyphenate-style-name "^1.0.2"
 

--- a/packages/fela-plugin-placeholder-prefixer/src/__tests__/placeholderPrefixer-test.js
+++ b/packages/fela-plugin-placeholder-prefixer/src/__tests__/placeholderPrefixer-test.js
@@ -1,9 +1,5 @@
 import placeholderPrefixer from '../index'
 
-const rendererMock = {
-  _mergeStyle: Object.assign,
-}
-
 describe('Placeholder prefixer plugin', () => {
   it('should add placeholder prefixes', () => {
     const style = {
@@ -13,7 +9,7 @@ describe('Placeholder prefixer plugin', () => {
       },
     }
 
-    expect(placeholderPrefixer()(style, 'RULE_TYPE', rendererMock)).toEqual({
+    expect(placeholderPrefixer()(style)).toEqual({
       width: 20,
       '::-webkit-input-placeholder': {
         color: 'red',

--- a/packages/fela-plugin-prefixer/package.json
+++ b/packages/fela-plugin-prefixer/package.json
@@ -23,7 +23,7 @@
   "author": "Robin Frischmann",
   "license": "MIT",
   "dependencies": {
-    "css-in-js-utils": "^2.0.0",
+    "css-in-js-utils": "^3.0.0",
     "fast-loops": "^1.0.0",
     "fela-plugin-fallback-value": "^5.0.18",
     "inline-style-prefixer": "^4.0.0",

--- a/packages/fela-plugin-prefixer/yarn.lock
+++ b/packages/fela-plugin-prefixer/yarn.lock
@@ -12,6 +12,12 @@ css-in-js-utils@^2.0.0:
   dependencies:
     hyphenate-style-name "^1.0.2"
 
+css-in-js-utils@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-3.0.0.tgz#4379185f5cc79f9eba39b4e795c317f253ffaa40"
+  dependencies:
+    hyphenate-style-name "^1.0.2"
+
 fast-loops@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fast-loops/-/fast-loops-1.0.0.tgz#2cdd7e0ff67343b2b5f5e627d855a50b4bed559a"

--- a/packages/fela-plugin-simulate/package.json
+++ b/packages/fela-plugin-simulate/package.json
@@ -25,7 +25,7 @@
     "fela": "^6.1.7"
   },
   "dependencies": {
-    "css-in-js-utils": "^2.0.0",
+    "css-in-js-utils": "^3.0.0",
     "isobject": "^3.0.1"
   }
 }

--- a/packages/fela-plugin-simulate/src/__tests__/simulate-test.js
+++ b/packages/fela-plugin-simulate/src/__tests__/simulate-test.js
@@ -13,7 +13,7 @@ describe('Simulating nested styles', () => {
     }
 
     expect(
-      simulate()(style, undefined, rendererMock, {
+      simulate()(style, undefined, undefined, {
         simulate: {
           ':hover': true,
         },
@@ -39,7 +39,7 @@ describe('Simulating nested styles', () => {
     }
 
     expect(
-      simulate()(style, undefined, rendererMock, {
+      simulate()(style, undefined, undefined, {
         simulate: {
           '@media (min-height: 300px)': true,
           ':hover': false,
@@ -67,7 +67,7 @@ describe('Simulating nested styles', () => {
     }
 
     expect(
-      simulate()(style, undefined, rendererMock, {
+      simulate()(style, undefined, undefined, {
         simulate: {
           '@media (min-height: 300px)': true,
           ':hover': true,

--- a/packages/fela-plugin-simulate/src/__tests__/simulate-test.js
+++ b/packages/fela-plugin-simulate/src/__tests__/simulate-test.js
@@ -1,9 +1,5 @@
 import simulate from '../index'
 
-const rendererMock = {
-  _mergeStyle: Object.assign,
-}
-
 describe('Simulating nested styles', () => {
   it('should simulate pseudo classes', () => {
     const style = {

--- a/packages/fela-plugin-simulate/src/index.js
+++ b/packages/fela-plugin-simulate/src/index.js
@@ -1,5 +1,6 @@
 /* @flow */
 import isPlainObject from 'isobject'
+import assignStyle from 'css-in-js-utils/lib/assignStyle'
 
 import type { DOMRenderer } from '../../../flowtypes/DOMRenderer'
 import type { NativeRenderer } from '../../../flowtypes/NativeRenderer'
@@ -18,7 +19,7 @@ function resolveSimulation(
       if (isPlainObject(value) && props.simulate[property]) {
         const resolvedValue = resolveSimulation(value, type, renderer, props)
 
-        renderer._mergeStyle(style, resolvedValue)
+        assignStyle(style, resolvedValue)
         delete style[property]
       }
     }

--- a/packages/fela-plugin-simulate/yarn.lock
+++ b/packages/fela-plugin-simulate/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-css-in-js-utils@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-2.0.0.tgz#5af1dd70f4b06b331f48d22a3d86e0786c0b9435"
+css-in-js-utils@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-3.0.0.tgz#4379185f5cc79f9eba39b4e795c317f253ffaa40"
   dependencies:
     hyphenate-style-name "^1.0.2"
 

--- a/packages/fela-plugin-unit/package.json
+++ b/packages/fela-plugin-unit/package.json
@@ -20,7 +20,7 @@
   "author": "Robin Frischmann",
   "license": "MIT",
   "dependencies": {
-    "css-in-js-utils": "^2.0.0",
+    "css-in-js-utils": "^3.0.0",
     "isobject": "^3.0.1"
   }
 }

--- a/packages/fela-plugin-unit/yarn.lock
+++ b/packages/fela-plugin-unit/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-css-in-js-utils@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-2.0.0.tgz#5af1dd70f4b06b331f48d22a3d86e0786c0b9435"
+css-in-js-utils@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-3.0.0.tgz#4379185f5cc79f9eba39b4e795c317f253ffaa40"
   dependencies:
     hyphenate-style-name "^1.0.2"
 

--- a/packages/fela-plugin-validator/package.json
+++ b/packages/fela-plugin-validator/package.json
@@ -22,7 +22,7 @@
   "author": "Robin Frischmann",
   "license": "MIT",
   "dependencies": {
-    "css-in-js-utils": "^2.0.0",
+    "css-in-js-utils": "^3.0.0",
     "csslint": "^1.0.5",
     "fela-utils": "^8.1.1",
     "isobject": "^3.0.1"

--- a/packages/fela-plugin-validator/yarn.lock
+++ b/packages/fela-plugin-validator/yarn.lock
@@ -6,9 +6,9 @@ clone@~2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.1.tgz#d217d1e961118e3ac9a4b8bba3285553bf647cdb"
 
-css-in-js-utils@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-2.0.0.tgz#5af1dd70f4b06b331f48d22a3d86e0786c0b9435"
+css-in-js-utils@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-3.0.0.tgz#4379185f5cc79f9eba39b4e795c317f253ffaa40"
   dependencies:
     hyphenate-style-name "^1.0.2"
 

--- a/packages/fela-tools/package.json
+++ b/packages/fela-tools/package.json
@@ -23,7 +23,7 @@
     "fela": "^6.1.7"
   },
   "dependencies": {
-    "css-in-js-utils": "^2.0.0",
+    "css-in-js-utils": "^3.0.0",
     "fast-loops": "^1.0.0",
     "fela": "^6.2.1",
     "fela-utils": "^8.1.1"

--- a/packages/fela-tools/src/__tests__/combineMultiRules-test.js
+++ b/packages/fela-tools/src/__tests__/combineMultiRules-test.js
@@ -29,7 +29,6 @@ describe('Combining multi rules', () => {
         fontSize: 12,
         lineHeight: 10,
       },
-      rendererMock,
     ]
 
     expect.assertions(2)

--- a/packages/fela-tools/src/__tests__/combineMultiRules-test.js
+++ b/packages/fela-tools/src/__tests__/combineMultiRules-test.js
@@ -1,9 +1,5 @@
 import combineMultiRules from '../combineMultiRules'
 
-const rendererMock = {
-  _mergeStyle: Object.assign,
-}
-
 describe('Combining multi rules', () => {
   it('should create a combined multi rule', () => {
     const multiRule = {

--- a/packages/fela-tools/src/combineMultiRules.js
+++ b/packages/fela-tools/src/combineMultiRules.js
@@ -1,6 +1,7 @@
 /* @flow */
 import objectReduce from 'fast-loops/lib/objectReduce'
 import arrayReduce from 'fast-loops/lib/arrayReduce'
+
 import { combineRules } from 'fela'
 
 function safeRule(ruleOrObject: Function | Object): Function {

--- a/packages/fela-tools/yarn.lock
+++ b/packages/fela-tools/yarn.lock
@@ -2,12 +2,11 @@
 # yarn lockfile v1
 
 
-css-in-js-utils@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz#3b472b398787291b47cfe3e44fecfdd9e914ba99"
+css-in-js-utils@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-3.0.0.tgz#4379185f5cc79f9eba39b4e795c317f253ffaa40"
   dependencies:
     hyphenate-style-name "^1.0.2"
-    isobject "^3.0.1"
 
 fast-loops@^1.0.0:
   version "1.0.0"
@@ -16,7 +15,3 @@ fast-loops@^1.0.0:
 hyphenate-style-name@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz#31160a36930adaf1fc04c6074f7eb41465d4ec4b"
-
-isobject@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"

--- a/packages/fela-utils/package.json
+++ b/packages/fela-utils/package.json
@@ -20,7 +20,7 @@
   "author": "Robin Frischmann",
   "license": "MIT",
   "dependencies": {
-    "css-in-js-utils": "^2.0.0",
+    "css-in-js-utils": "^3.0.0",
     "fast-loops": "^1.0.0",
     "string-hash": "^1.1.3"
   },

--- a/packages/fela-utils/yarn.lock
+++ b/packages/fela-utils/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-css-in-js-utils@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-2.0.0.tgz#5af1dd70f4b06b331f48d22a3d86e0786c0b9435"
+css-in-js-utils@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-3.0.0.tgz#4379185f5cc79f9eba39b4e795c317f253ffaa40"
   dependencies:
     hyphenate-style-name "^1.0.2"
 

--- a/packages/fela/README.md
+++ b/packages/fela/README.md
@@ -212,6 +212,7 @@ We'd love to help out. We also highly appreciate any feedback.
 - [Bookmyshow](https://in.bookmyshow.com/events)
 - [BdP LV RPS](http://www.bdp-rps.de)
 - [Cloudflare](https://www.cloudflare.com)
+- [Espressive](https://www.espressive.com)
 - [dm-drogerie markt](https://www.dm.de/arbeiten-und-lernen/arbeiten-bei-uns/filiadata-c534052.html)
 - [HelloFresh](https://www.hellofresh.de)
 - [Indoqa](https://www.indoqa.com)

--- a/packages/fela/package.json
+++ b/packages/fela/package.json
@@ -31,7 +31,7 @@
   "author": "Robin Frischmann",
   "license": "MIT",
   "dependencies": {
-    "css-in-js-utils": "^2.0.0",
+    "css-in-js-utils": "^3.0.0",
     "csstype": "^2.5.5",
     "fast-loops": "^1.0.0",
     "fela-utils": "^8.1.1",

--- a/packages/fela/src/__tests__/combineRules-test.js
+++ b/packages/fela/src/__tests__/combineRules-test.js
@@ -18,13 +18,10 @@ describe('Combining rules', () => {
     const combinedRule = combineRules(rule, anotherRule)
 
     expect(
-      combinedRule(
-        {
-          fontSize: 12,
-          lineHeight: 10,
-        },
-        rendererMock
-      )
+      combinedRule({
+        fontSize: 12,
+        lineHeight: 10,
+      })
     ).toEqual({
       color: 'red',
       backgroundColor: 'blue',
@@ -59,14 +56,11 @@ describe('Combining rules', () => {
     const combinedRule = combineRules(rule1, rule2, rule3, rule4)
 
     expect(
-      combinedRule(
-        {
-          fontSize: 12,
-          lineHeight: 10,
-          color: 'green',
-        },
-        rendererMock
-      )
+      combinedRule({
+        fontSize: 12,
+        lineHeight: 10,
+        color: 'green',
+      })
     ).toEqual({
       color: 'green',
       display: 'flex',

--- a/packages/fela/src/__tests__/combineRules-test.js
+++ b/packages/fela/src/__tests__/combineRules-test.js
@@ -1,9 +1,5 @@
 import combineRules from '../combineRules'
 
-const rendererMock = {
-  _mergeStyle: Object.assign,
-}
-
 describe('Combining rules', () => {
   it('should create a combined rule', () => {
     const rule = props => ({

--- a/packages/fela/src/combineRules.js
+++ b/packages/fela/src/combineRules.js
@@ -3,13 +3,10 @@ import assignStyle from 'css-in-js-utils/lib/assignStyle'
 import arrayReduce from 'fast-loops/lib/arrayReduce'
 
 export default function combineRules(...rules: Array<Function>): Function {
-  return (props, renderer) => {
-    const merge = renderer._mergeStyle || assignStyle
-
-    return arrayReduce(
+  return (props, renderer) =>
+    arrayReduce(
       rules,
-      (style, rule) => merge(style, rule(props, renderer)),
+      (style, rule) => assignStyle(style, rule(props, renderer)),
       {}
     )
-  }
 }

--- a/packages/fela/src/createRenderer.js
+++ b/packages/fela/src/createRenderer.js
@@ -1,6 +1,5 @@
 /* @flow */
 import cssifyDeclaration from 'css-in-js-utils/lib/cssifyDeclaration'
-import assignStyle from 'css-in-js-utils/lib/assignStyle'
 import arrayEach from 'fast-loops/lib/arrayEach'
 import isPlainObject from 'isobject'
 
@@ -184,8 +183,6 @@ export default function createRenderer(
         type: CLEAR_TYPE,
       })
     },
-
-    _mergeStyle: assignStyle,
 
     _renderStyle(style: Object = {}, props: Object = {}): string {
       const processedStyle = processStyleWithPlugins(

--- a/packages/fela/yarn.lock
+++ b/packages/fela/yarn.lock
@@ -2,12 +2,11 @@
 # yarn lockfile v1
 
 
-css-in-js-utils@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz#3b472b398787291b47cfe3e44fecfdd9e914ba99"
+css-in-js-utils@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-3.0.0.tgz#4379185f5cc79f9eba39b4e795c317f253ffaa40"
   dependencies:
     hyphenate-style-name "^1.0.2"
-    isobject "^3.0.1"
 
 csstype@^2.5.5:
   version "2.5.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2248,6 +2248,12 @@ css-in-js-utils@^2.0.0:
     hyphenate-style-name "^1.0.2"
     isobject "^3.0.1"
 
+css-in-js-utils@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-3.0.0.tgz#4379185f5cc79f9eba39b4e795c317f253ffaa40"
+  dependencies:
+    hyphenate-style-name "^1.0.2"
+
 css-select@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guide-lines at the bottom.
------------------------------------------->

## Description
With the soon landing version 3.0.0 of css-in-js-utils, we do not need that enhancer at all, as the assignStyle already handles merging arrays.

## ToDo
- [x] wait until css-in-js-utils@3.0.0 is released
- [ ] remove fela-combine-arrays after release

## Versioning
<!------------------------------------------
  Please add all updated packages and propose new versions following the semantic versioning guidelines
------------------------------------------->


#### Major

#### Minor

#### Patch
- fela
- fela-native
- fela-plugin-extend
- fela-plugin-custom-property
- fela-plugin-simulate
- fela-plugin-native-media-query

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

