### PR TITLE
#600 fix problem with fela-monolithic and rules rendering

### DIFF
--- a/examples/example-typescript/package.json
+++ b/examples/example-typescript/package.json
@@ -25,6 +25,7 @@
     "@types/react": "^16.0.18",
     "@types/react-dom": "^16.0.2",
     "fela": "^6.2.2",
+    "fela-monolithic": "^5.0.26",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-fela": "^8.0.2"

--- a/examples/example-typescript/src/felaConfig.ts
+++ b/examples/example-typescript/src/felaConfig.ts
@@ -1,3 +1,6 @@
 import { createRenderer } from 'fela'
+import monolithic from 'fela-monolithic'
 
-export const renderer = createRenderer()
+export const renderer = createRenderer({
+  enhancers: [ monolithic({}) ]
+})

--- a/examples/example-typescript/src/index.tsx
+++ b/examples/example-typescript/src/index.tsx
@@ -1,22 +1,20 @@
 import * as React from "react";
-import {createRenderer} from "fela";
 import * as ReactDOM from "react-dom";
 import {Provider, ThemeProvider} from 'react-fela';
 import ComplexComponent from './components/ComplexComponent';
 import {theme} from "./Theme";
+import {renderer} from "./felaConfig";
 
 const extendStyles = {
   container: {
     borderColor: 'black',
     borderRadius: '10px',
     borderStyle: 'solid'
-  } as React.CSSProperties
+  }
 };
 
-export const renderer = createRenderer();
-
 ReactDOM.render(
-  <Provider renderer={renderer}>
+  <Provider renderer={renderer} rehydrate={false}>
     <ThemeProvider theme={theme}>
       <ComplexComponent fontScale={10} extend={extendStyles}/>
     </ThemeProvider>

--- a/packages/fela-bindings/src/ProviderFactory.js
+++ b/packages/fela-bindings/src/ProviderFactory.js
@@ -25,8 +25,8 @@ export default function ProviderFactory(
     constructor(props: Object, context: Object) {
       super(props, context)
 
-      if (props.rehydrate && hasDOM(props.renderer)) {
-        if (hasServerRenderedStyle()) {
+      if (hasDOM(props.renderer)) {
+        if (props.rehydrate && hasServerRenderedStyle()) {
           rehydrate(props.renderer)
         } else {
           render(props.renderer)

--- a/packages/fela-bindings/src/__tests__/feFactory-test.js
+++ b/packages/fela-bindings/src/__tests__/feFactory-test.js
@@ -15,6 +15,15 @@ import { THEME_CHANNEL } from '../themeChannel'
 
 import feFactory from '../feFactory'
 
+jest.mock('fela-dom', () => ({
+  render: () => undefined,
+  rehydrate: () => undefined,
+}))
+
+afterAll(() => {
+  jest.unmock('fela-dom')
+})
+
 const FelaTheme = FelaThemeFactory(Component, {
   [THEME_CHANNEL]: PropTypes.object,
 })

--- a/packages/fela-dom/src/dom/connection/insertRule.js
+++ b/packages/fela-dom/src/dom/connection/insertRule.js
@@ -47,6 +47,10 @@ export default function insertRule(
 
     cssRules[index].score = score
   } catch (e) {
-    // TODO: warning?
+    console.warn(
+      `An error occurred while inserting the rules into DOM.\n`,
+      declaration.replace(/;/g, ';\n'),
+      e
+    )
   }
 }

--- a/packages/fela-monolithic/src/__tests__/monolithic-test.js
+++ b/packages/fela-monolithic/src/__tests__/monolithic-test.js
@@ -87,7 +87,7 @@ describe('Monolithic enhancer', () => {
     const className = renderer.renderRule(rule)
 
     expect(renderToString(renderer)).toEqual(
-      `.${className}:hover{color:blue}.${className}{color:red}`
+      `.${className}{color:red}.${className}:hover{color:blue}`
     )
   })
 

--- a/packages/fela-monolithic/src/index.js
+++ b/packages/fela-monolithic/src/index.js
@@ -72,7 +72,9 @@ function useMonolithicRenderer(
               combinedSupport
             )
           } else {
-            // TODO: warning
+            console.warn(`The object key "${property}" is not a valid nested key in Fela. 
+Maybe you forgot to add a plugin to resolve it? 
+Check http://fela.js.org/docs/basics/Rules.html#styleobject for more information.`)
           }
         } else if (!isUndefinedValue(value)) {
           ruleset[property] = value
@@ -93,6 +95,8 @@ function useMonolithicRenderer(
         selector,
         declaration: css,
         media,
+        pseudo,
+        support,
       }
 
       const declarationReference = selector + media + support


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guide-lines at the bottom.
------------------------------------------->

## Description
Fix propblem described in https://github.com/rofrischmann/fela/issues/600
+ fix behavior when rehydrate prop in provider is false no any rule rendered (it seems not what was expected)
+ updated typescript example (can be used for test behavior with rehydrate)

## Versioning
<!------------------------------------------
  Please add all updated packages and propose new versions following the semantic versioning guidelines
------------------------------------------->


#### Major

#### Minor

#### Patch
fela-bindings
fela-monolithic
fela-dom

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

