### PR TITLE
Improve generation of pretty selectors

### DIFF
--- a/packages/fela-bindings/src/__tests__/__snapshots__/createComponentFactory-test.js.snap
+++ b/packages/fela-bindings/src/__tests__/__snapshots__/createComponentFactory-test.js.snap
@@ -510,7 +510,7 @@ Array [
 exports[`Creating Components from Fela rules should use a dev-friendly className and the selectorPrefix 1`] = `
 Array [
   "<style>
-    .Fela-Button_div__abrv9k {
+    .Fela-Button_abrv9k {
         font-size: 16
     }
 </style>",
@@ -519,7 +519,7 @@ Array [
         _felaTheme={Object {}}
     >
         <div
-            className="Fela-Button_div__abrv9k"
+            className="Fela-Button_abrv9k"
         />
     </Button>
 </Button>,
@@ -529,7 +529,7 @@ Array [
 exports[`Creating Components from Fela rules should use a dev-friendly className with monolithic renderer 1`] = `
 Array [
   "<style>
-    .Button_div__abrv9k {
+    .Button_abrv9k {
         font-size: 16
     }
 </style>",
@@ -538,7 +538,7 @@ Array [
         _felaTheme={Object {}}
     >
         <div
-            className="Button_div__abrv9k"
+            className="Button_abrv9k"
         />
     </Button>
 </Button>,
@@ -892,7 +892,7 @@ Array [
 exports[`Creating Components with a Proxy for props from Fela rules should replace rare unallowed symbols in className with underscore 1`] = `
 Array [
   "<style>
-    .rule_1_______________abrv9k {
+    .1_abrv9k {
         font-size: 16
     }
 </style>",
@@ -901,7 +901,7 @@ Array [
         _felaTheme={Object {}}
     >
         <1!@#$%^&*{}/=\\
-            className="rule_1_______________abrv9k"
+            className="1_abrv9k"
         >
             <div />
         </1!@#$%^&*{}/=\\>
@@ -913,7 +913,7 @@ Array [
 exports[`Creating Components with a Proxy for props from Fela rules should replace unallowed symbols in className with underscore 1`] = `
 Array [
   "<style>
-    .rule_connect_Component___abrv9k {
+    .connect_Component_abrv9k {
         font-size: 16
     }
 </style>",
@@ -922,7 +922,7 @@ Array [
         _felaTheme={Object {}}
     >
         <connect(Component)
-            className="rule_connect_Component___abrv9k"
+            className="connect_Component_abrv9k"
         >
             <div />
         </connect(Component)>
@@ -934,7 +934,7 @@ Array [
 exports[`Creating Components with a Proxy for props from Fela rules should use a dev-friendly className and the selectorPrefix 1`] = `
 Array [
   "<style>
-    .Fela-Button_div__abrv9k {
+    .Fela-Button_abrv9k {
         font-size: 16
     }
 </style>",
@@ -943,7 +943,7 @@ Array [
         _felaTheme={Object {}}
     >
         <div
-            className="Fela-Button_div__abrv9k"
+            className="Fela-Button_abrv9k"
         />
     </Button>
 </Button>,
@@ -953,7 +953,7 @@ Array [
 exports[`Creating Components with a Proxy for props from Fela rules should use a dev-friendly className with monolithic renderer 1`] = `
 Array [
   "<style>
-    .Button_div__abrv9k {
+    .Button_abrv9k {
         font-size: 16
     }
 </style>",
@@ -962,7 +962,7 @@ Array [
         _felaTheme={Object {}}
     >
         <div
-            className="Button_div__abrv9k"
+            className="Button_abrv9k"
         />
     </Button>
 </Button>,

--- a/packages/fela-bindings/src/connectFactory.js
+++ b/packages/fela-bindings/src/connectFactory.js
@@ -5,6 +5,7 @@ import { combineMultiRules } from 'fela-tools'
 import shallowCompare from 'react-addons-shallow-compare'
 
 import generateDisplayName from './generateDisplayName'
+import generateSelectorPrefix from './generateSelectorPrefix'
 import hoistStatics from './hoistStatics'
 
 export type ConnectConfig = {
@@ -68,14 +69,10 @@ export default function connectFactory(
             process.env.NODE_ENV !== 'production' &&
             renderer.prettySelectors
           ) {
-            const componentName =
-              typeof component === 'string'
-                ? component
-                : component.displayName || component.name || ''
+            const componentName = component.displayName || component.name || ''
 
             objectEach(preparedRules, (rule, name) => {
-              const displayName = rule.name ? rule.name : 'FelaComponent'
-              rule.selectorPrefix = `${displayName}_${componentName}_${name}_`
+              rule.selectorPrefix = generateSelectorPrefix(componentName, name)
             })
           }
 

--- a/packages/fela-bindings/src/createComponentFactory.js
+++ b/packages/fela-bindings/src/createComponentFactory.js
@@ -4,6 +4,7 @@ import { combineRules } from 'fela'
 import hoistStatics from './hoistStatics'
 import extractPassThroughProps from './extractPassThroughProps'
 import extractUsedProps from './extractUsedProps'
+import generateSelectorPrefix from './generateSelectorPrefix'
 import resolvePassThrough from './resolvePassThrough'
 import resolveUsedProps from './resolveUsedProps'
 
@@ -58,17 +59,12 @@ export default function createComponentFactory(
 
       // improve developer experience with monolithic renderer
       if (process.env.NODE_ENV !== 'production' && renderer.prettySelectors) {
-        const replaceUnallowedSymbolsWithUnderscore = cn =>
-          cn.replace(/[^_a-z0-9-]/gi, '_')
-
         const componentName =
           typeof type === 'string'
-            ? type
-            : replaceUnallowedSymbolsWithUnderscore(
-                type.displayName || type.name || ''
-              )
+            ? displayName
+            : type.displayName || type.name || ''
 
-        combinedRule.selectorPrefix = `${displayName}_${componentName}_`
+        combinedRule.selectorPrefix = generateSelectorPrefix(componentName)
       }
       // compose passThrough props from arrays or functions
       const resolvedPassThrough = [

--- a/packages/fela-bindings/src/generateSelectorPrefix.js
+++ b/packages/fela-bindings/src/generateSelectorPrefix.js
@@ -1,0 +1,15 @@
+/* @flow */
+const sanitizeComponentDisplayName = cn =>
+  cn
+    .replace(/[^_a-z0-9-]/gi, '_')
+    .replace(/_{2,}/g, '_')
+    .replace(/(^_|_$)/g, '')
+
+export default function generateSelectorPrefix(
+  displayName: string,
+  ruleName?: string
+): string {
+  const sanitizedDisplayName = sanitizeComponentDisplayName(displayName)
+
+  return ruleName ? `${sanitizedDisplayName}_${ruleName}` : sanitizedDisplayName
+}

--- a/packages/fela-identifier/src/__tests__/__snapshots__/identifier-test.js.snap
+++ b/packages/fela-identifier/src/__tests__/__snapshots__/identifier-test.js.snap
@@ -14,17 +14,17 @@ exports[`Fela identifier enhancer identifier enhancer should not remove meta inf
       }
       styles={
         Object {
-          "rule1": "rule1_MyComponent_rule1__zuf8d5",
-          "rule2": "rule2_MyComponent_rule2__137u7ef",
+          "rule1": "MyComponent_rule1_zuf8d5",
+          "rule2": "MyComponent_rule2_137u7ef",
         }
       }
     >
       <div>
         <span
-          className="rule1_MyComponent_rule1__zuf8d5"
+          className="MyComponent_rule1_zuf8d5"
         />
         <span
-          className="rule2_MyComponent_rule2__137u7ef"
+          className="MyComponent_rule2_137u7ef"
         />
       </div>
     </MyComponent>

--- a/packages/fela-monolithic/src/__tests__/__snapshots__/integration-react-test.js.snap
+++ b/packages/fela-monolithic/src/__tests__/__snapshots__/integration-react-test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Monolithic enhancer React integration should generate pretty selectors for connect 1`] = `".FelaComponent_BaseComponent_header__137u7ef{color:red}.FelaComponent_BaseComponent_body__1jzdmtb{color:green}.FelaComponent_BaseComponent_footer__1tsdo2i{color:blue}"`;
+exports[`Monolithic enhancer React integration should generate pretty selectors for connect 1`] = `".BaseComponent_header_137u7ef{color:red}.BaseComponent_body_1jzdmtb{color:green}.BaseComponent_footer_1tsdo2i{color:blue}"`;
 
-exports[`Monolithic enhancer React integration should generate pretty selectors for createComponent 1`] = `".FelaComponent_BaseComponent__137u7ef{color:red}"`;
+exports[`Monolithic enhancer React integration should generate pretty selectors for createComponent 1`] = `".BaseComponent_137u7ef{color:red}"`;
 
 exports[`Monolithic enhancer React integration should render a single class 1`] = `"._137u7ef{color:red}"`;


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guide-lines at the bottom.
------------------------------------------->

## Description

This PR improves the generation of selector prefixes for pretty selectors, making them prettier. The rule name was repeated and multiple adjacent `_` could end up in the generated selector prefix: see diff on snapshots.

A new function was created (`generateSelectorPrefix`) enabling common logic for `connect` and `createComponent` (like stripping class names of not allowed characters).

## Versioning
<!------------------------------------------
  Please add all updated packages and propose new versions following the semantic versioning guidelines
------------------------------------------->


#### Major

#### Minor

#### Patch

`fela-bindings` and all dependent packages (`react-fela`, `jest-react-fela`, `inferno-fela`, `jest-inferno-fela`, `preact-fela`, `jest-preact-fela`)

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

