### PR TITLE
Pass children to <FelaComponent render={...} />

### DIFF
--- a/docs/api/bindings/FelaComponent.md
+++ b/docs/api/bindings/FelaComponent.md
@@ -16,6 +16,7 @@ FelaComponent is an alternative component to the [createComponent](createCompone
 | --- | --- | --- | --- |
 | className | *string* | | The class names for the rendered *style* object |
 | theme | *Object* | `{}` | The theme object which is passed down via context |
+| children | *Element* | `{}` | The component children |
 
 ## Imports
 ```javascript

--- a/docs/api/bindings/FelaComponent.md
+++ b/docs/api/bindings/FelaComponent.md
@@ -16,7 +16,7 @@ FelaComponent is an alternative component to the [createComponent](createCompone
 | --- | --- | --- | --- |
 | className | *string* | | The class names for the rendered *style* object |
 | theme | *Object* | `{}` | The theme object which is passed down via context |
-| children | *Element* | `{}` | The component children |
+| children | *Element* | | The component children |
 
 ## Imports
 ```javascript

--- a/packages/fela-bindings/src/FelaComponentFactory.js
+++ b/packages/fela-bindings/src/FelaComponentFactory.js
@@ -24,6 +24,7 @@ export default function FelaComponentFactory(
         if (render instanceof Function) {
           return render({
             className,
+            children,
             theme,
           })
         }


### PR DESCRIPTION
## Description
`<FelaComponent render={...} />` currently does not get the children. Accessing the children can be handy if the render function comes from outside your component.

## Example
```javascript
const CustomList = () => (
  <List
    render={({ className, children }) => (
      <div className={className}>{children}</div>
    )}
  />
);

const List = ({ render }) => (
  <FelaComponent render={render}>Hello</FelaComponent>
);
```
## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Documentation has been added/updated


