### PR TITLE
FelaDom querySelector ignores media and support attributes if they are not defined

### DIFF
--- a/packages/fela-dom/src/dom/connection/__tests__/queryNode-test.js
+++ b/packages/fela-dom/src/dom/connection/__tests__/queryNode-test.js
@@ -1,0 +1,34 @@
+import { RULE_TYPE } from 'fela-utils'
+
+import queryNode from '../queryNode'
+
+it('should not query nodes with media or support attributes if media or support are not defined', () => {
+  const nodeValid =
+    '<style data-fela-type="RULE" type="text/css">.a{color: red}</style>'
+  const nodeInvalid =
+    '<style data-fela-type="RULE" type="text/css" media="screen and (min-width: 1280px)">.b{color: blue}</style>'
+
+  document.head.innerHTML = nodeInvalid + nodeValid
+
+  expect(
+    queryNode({
+      type: RULE_TYPE,
+    }).outerHTML
+  ).toBe(nodeValid)
+})
+
+it('should query nodes with media or support attributes if media or support are defined', () => {
+  const nodeInvalid =
+    '<style data-fela-type="RULE" type="text/css">.a{color: red}</style>'
+  const nodeValid =
+    '<style data-fela-type="RULE" type="text/css" media="screen and (min-width: 1280px)">.b{color: blue}</style>'
+
+  document.head.innerHTML = nodeInvalid + nodeValid
+
+  expect(
+    queryNode({
+      type: RULE_TYPE,
+      media: 'screen and (min-width: 1280px)',
+    }).outerHTML
+  ).toBe(nodeValid)
+})

--- a/packages/fela-dom/src/dom/connection/queryNode.js
+++ b/packages/fela-dom/src/dom/connection/queryNode.js
@@ -6,8 +6,10 @@ export default function queryNode({
   media,
   support,
 }: NodeAttributes): ?Object {
-  const mediaQuery = media ? `[media="${media}"]` : ''
-  const supportQuery = support ? '[data-fela-support="true"]' : ''
+  const mediaQuery = media ? `[media="${media}"]` : ':not([media])'
+  const supportQuery = support
+    ? '[data-fela-support="true"]'
+    : ':not([support])'
 
   return document.querySelector(
     `[data-fela-type="${type}"]${supportQuery}${mediaQuery}`


### PR DESCRIPTION


## Description
closes #632 


#### Major
8

#### Minor
0

#### Patch
5

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

