### PR TITLE
Disabling inserting warnings

### DIFF
--- a/packages/fela-dom/src/dom/connection/insertRule.js
+++ b/packages/fela-dom/src/dom/connection/insertRule.js
@@ -47,10 +47,13 @@ export default function insertRule(
 
     cssRules[index].score = score
   } catch (e) {
-    console.warn(
-      `An error occurred while inserting the rules into DOM.\n`,
-      declaration.replace(/;/g, ';\n'),
-      e
-    )
+    // We're disabled these warnings due to false-positive errors with browser prefixes
+    // See https://github.com/rofrischmann/fela/issues/634
+    
+    // console.warn(
+    //   `An error occurred while inserting the rules into DOM.\n`,
+    //   declaration.replace(/;/g, ';\n'),
+    //   e
+    // )
   }
 }


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guide-lines at the bottom.
------------------------------------------->

## Description
This PR disables warnings thrown on crashing `insertRule` calls as they're mostly false-positive concerning browser differences rather than actual errors that would lead to wrong styling.

## Versioning
<!------------------------------------------
  Please add all updated packages and propose new versions following the semantic versioning guidelines
------------------------------------------->


#### Major

#### Minor

#### Patch
- fela-dom

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [ ] The code was formatted using Prettier (`yarn run format`)
- [ ] The code has no linting errors (`yarn run lint`)
- [ ] All tests are passing (`yarn run test`) 
- [ ] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [ ] Tests have been added/updated
- [ ] Documentation has been added/updated
- [ ] My changes have proper flow-types

