### PR TITLE
Fix theme providers not re-rendering their children

### DIFF
--- a/packages/fela-bindings/package.json
+++ b/packages/fela-bindings/package.json
@@ -28,8 +28,7 @@
     "fast-loops": "^1.0.0",
     "fela-dom": "^10.0.1",
     "fela-tools": "^10.0.1",
-    "react-addons-shallow-compare": "^15.6.2",
-    "shallow-equal": "^1.0.0"
+    "react-addons-shallow-compare": "^15.6.2"
   },
   "devDependencies": {
     "react": "^16.6.1"

--- a/packages/fela-bindings/src/ThemeProviderFactory.js
+++ b/packages/fela-bindings/src/ThemeProviderFactory.js
@@ -1,5 +1,4 @@
 /* @flow */
-import shallowEqual from 'shallow-equal/objects'
 import objectEach from 'fast-loops/lib/objectEach'
 
 export default function ThemeProviderFactory(
@@ -10,10 +9,6 @@ export default function ThemeProviderFactory(
   statics?: Object
 ): any {
   class ThemeProvider extends BaseComponent {
-    shouldComponentUpdate(nextProps) {
-      return !shallowEqual(this.props.theme, nextProps.theme)
-    }
-
     render(): Object {
       return createElement(
         ThemeContext.Provider,


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guidelines at the bottom.
------------------------------------------->

## Description

`shouldComponentUpdate` on theme providers prevent them to re-render their children if the provided theme hasn't changed. I understand it might have been added to prevent re-rendering all styled fela components if the theme hasn't changed, but React context uses reference identity to determine when to re-render. After checking, [create-inferno-context](https://github.com/kurdin/create-inferno-context/blob/master/src/implementation.js#L67-L69) and [preact-context](https://github.com/valotas/preact-context/blob/master/src/context.ts#L87) also have the same behaviour.

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

