### PR TITLE
Fix Provider deprecation warning

### DIFF
--- a/packages/inferno-fela/src/Provider.js
+++ b/packages/inferno-fela/src/Provider.js
@@ -1,0 +1,14 @@
+/* @flow */
+import { createElement } from 'inferno-create-element'
+
+import RendererProvider from './RendererProvider'
+
+import deprecate from './_deprecate'
+
+export default function Provider(props) {
+  deprecate(
+    'Importing `Provider` from inferno-fela is deprecated. Import `RendererProvider` instead.\nSee http://fela.js.org/docs/api/bindings/renderer-provider'
+  )
+
+  return createElement(RendererProvider, props)
+}

--- a/packages/inferno-fela/src/_deprecate.js
+++ b/packages/inferno-fela/src/_deprecate.js
@@ -1,7 +1,7 @@
 const cache = {}
 const isProd = process.env.NODE_ENV === 'production'
 
-export function deprecate(message) {
+export default function deprecate(message) {
   if (!isProd && !cache[message]) {
     console.warn(message)
     cache[message] = true

--- a/packages/inferno-fela/src/_deprecate.js
+++ b/packages/inferno-fela/src/_deprecate.js
@@ -7,8 +7,3 @@ export function deprecate(message) {
     cache[message] = true
   }
 }
-
-export function interceptDeprecation(component, message) {
-  deprecate(message)
-  return component
-}

--- a/packages/inferno-fela/src/index.js
+++ b/packages/inferno-fela/src/index.js
@@ -4,17 +4,11 @@ import createComponent from './createComponent'
 import createComponentWithProxy from './createComponentWithProxy'
 import FelaComponent from './FelaComponent'
 import FelaTheme from './FelaTheme'
+import Provider from './Provider'
 import RendererProvider from './RendererProvider'
 import ThemeProvider from './ThemeProvider'
 import withTheme from './withTheme'
 import fe from './fe'
-
-import { interceptDeprecation } from './_deprecate'
-
-const Provider = interceptDeprecation(
-  RendererProvider,
-  'Importing `Provider` from inferno-fela is deprecated. Import `RendererProvider` instead.\nSee http://fela.js.org/docs/api/bindings/renderer-provider'
-)
 
 export {
   connect,

--- a/packages/preact-fela/src/Provider.js
+++ b/packages/preact-fela/src/Provider.js
@@ -1,0 +1,14 @@
+/* @flow */
+import { h as createElement } from 'preact'
+
+import RendererProvider from './RendererProvider'
+
+import deprecate from './_deprecate'
+
+export default function Provider(props) {
+  deprecate(
+    'Importing `Provider` from preact-fela is deprecated. Import `RendererProvider` instead.\nSee http://fela.js.org/docs/api/bindings/renderer-provider'
+  )
+
+  return createElement(RendererProvider, props)
+}

--- a/packages/preact-fela/src/_deprecate.js
+++ b/packages/preact-fela/src/_deprecate.js
@@ -1,7 +1,7 @@
 const cache = {}
 const isProd = process.env.NODE_ENV === 'production'
 
-export function deprecate(message) {
+export default function deprecate(message) {
   if (!isProd && !cache[message]) {
     console.warn(message)
     cache[message] = true

--- a/packages/preact-fela/src/_deprecate.js
+++ b/packages/preact-fela/src/_deprecate.js
@@ -7,8 +7,3 @@ export function deprecate(message) {
     cache[message] = true
   }
 }
-
-export function interceptDeprecation(component, message) {
-  deprecate(message)
-  return component
-}

--- a/packages/preact-fela/src/index.js
+++ b/packages/preact-fela/src/index.js
@@ -4,17 +4,11 @@ import createComponent from './createComponent'
 import createComponentWithProxy from './createComponentWithProxy'
 import FelaComponent from './FelaComponent'
 import FelaTheme from './FelaTheme'
+import Provider from './Provider'
 import RendererProvider from './RendererProvider'
 import ThemeProvider from './ThemeProvider'
 import withTheme from './withTheme'
 import fe from './fe'
-
-import { interceptDeprecation } from './_deprecate'
-
-const Provider = interceptDeprecation(
-  RendererProvider,
-  'Importing `Provider` from preact-fela is deprecated. Import `RendererProvider` instead.\nSee http://fela.js.org/docs/api/bindings/renderer-provider'
-)
 
 export {
   connect,

--- a/packages/react-fela/src/Provider.js
+++ b/packages/react-fela/src/Provider.js
@@ -1,0 +1,14 @@
+/* @flow */
+import { createElement } from 'react'
+
+import RendererProvider from './RendererProvider'
+
+import deprecate from './_deprecate'
+
+export default function Provider(props) {
+  deprecate(
+    'Importing `Provider` from react-fela is deprecated. Import `RendererProvider` instead.\nSee http://fela.js.org/docs/api/bindings/renderer-provider'
+  )
+
+  return createElement(RendererProvider, props)
+}

--- a/packages/react-fela/src/_deprecate.js
+++ b/packages/react-fela/src/_deprecate.js
@@ -1,7 +1,7 @@
 const cache = {}
 const isProd = process.env.NODE_ENV === 'production'
 
-export function deprecate(message) {
+export default function deprecate(message) {
   if (!isProd && !cache[message]) {
     console.warn(message)
     cache[message] = true

--- a/packages/react-fela/src/_deprecate.js
+++ b/packages/react-fela/src/_deprecate.js
@@ -7,8 +7,3 @@ export function deprecate(message) {
     cache[message] = true
   }
 }
-
-export function interceptDeprecation(component, message) {
-  deprecate(message)
-  return component
-}

--- a/packages/react-fela/src/index.js
+++ b/packages/react-fela/src/index.js
@@ -4,17 +4,11 @@ import createComponent from './createComponent'
 import createComponentWithProxy from './createComponentWithProxy'
 import FelaComponent from './FelaComponent'
 import FelaTheme from './FelaTheme'
+import Provider from './Provider'
 import RendererProvider from './RendererProvider'
 import ThemeProvider from './ThemeProvider'
 import withTheme from './withTheme'
 import fe from './fe'
-
-import { interceptDeprecation } from './_deprecate'
-
-const Provider = interceptDeprecation(
-  RendererProvider,
-  'Importing `Provider` from react-fela is deprecated. Import `RendererProvider` instead.\nSee http://fela.js.org/docs/api/bindings/renderer-provider'
-)
 
 export {
   connect,


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guidelines at the bottom.
------------------------------------------->

## Description
In current versions, there's a false-positive deprecation warning saying "Importing Provider is deprecated" although it's not even deprecated.

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [ ] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

