### PR TITLE
Fix broken MIGRATION.md API links.

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -16,17 +16,17 @@ All older APIs should still work, but will now render a deprecation warning with
 * preact-fela
 * inferno-fela
 
---- 
+---
 
 ### FelaTheme
 
-[Codemod](https://github.com/rofrischmann/fela/tree/master/packages/fela-codemods#felatheme) | [API Reference](http://fela.js.org/docs/api/bindings/fela-theme)
+[Codemod](https://github.com/rofrischmann/fela/tree/master/packages/fela-codemods#felatheme) | [API Reference](http://fela.js.org/docs/api/bindings/FelaTheme.html)
 
 The FelaTheme component now no longer uses the special `render` prop to pass a render function, but uses `children` instead.<br>
 
 ### FelaComponent
 
-[Codemod](https://github.com/rofrischmann/fela/tree/master/packages/fela-codemods#felacomponent) | [API Reference](http://fela.js.org/docs/api/bindings/fela-component)
+[Codemod](https://github.com/rofrischmann/fela/tree/master/packages/fela-codemods#felacomponent) | [API Reference](http://fela.js.org/docs/api/bindings/FelaComponent.html)
 
 The same goes for FelaComponent. We now use `children` directly rather than `render`. In order to pass a primitive render type, one may now use the `as` prop.
 
@@ -34,6 +34,6 @@ Instead of accepting both `style` and `rule` it now only accepts `style` but all
 
 ### RendererProvider
 
-[Codemod](https://github.com/rofrischmann/fela/tree/master/packages/fela-codemods#rendererprovider) | [API Reference](http://fela.js.org/docs/api/bindings/renderer-provider)
+[Codemod](https://github.com/rofrischmann/fela/tree/master/packages/fela-codemods#rendererprovider) | [API Reference](http://fela.js.org/docs/api/bindings/RendererProvider.html)
 
-The old `Provider` component has been renamed to `RendererProvider` for more clarity and specificity. 
+The old `Provider` component has been renamed to `RendererProvider` for more clarity and specificity.


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guidelines at the bottom.
------------------------------------------->

## Description
The "API Reference" Links on the [Migration docs](http://fela.js.org/MIGRATION.html) are broken.  This PR updates them to the correct URLs.

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [ ] Tests have been added/updated
- [x] Documentation has been added/updated
- [ ] My changes have proper flow-types

