### PR TITLE
Improve DOM rendering performance

### DIFF
--- a/packages/fela-dom/src/dom/connection/createSubscription.js
+++ b/packages/fela-dom/src/dom/connection/createSubscription.js
@@ -23,6 +23,7 @@ export default function createSubscription(renderer: DOMRenderer): Function {
       )
 
       renderer.nodes = {}
+      renderer.scoreIndex = {}
       return
     }
 

--- a/packages/fela-dom/src/dom/rehydrate.js
+++ b/packages/fela-dom/src/dom/rehydrate.js
@@ -53,15 +53,23 @@ export default function rehydrate(renderer: DOMRenderer): void {
         // can yield null for node.sheet
         // https://github.com/rofrischmann/fela/issues/431#issuecomment-423239591
         if (node.sheet && node.sheet.cssRules) {
-          arrayEach(node.sheet.cssRules, rule => {
+          const nodeReference = media + support
+
+          arrayEach(node.sheet.cssRules, (rule, index) => {
             const selectorText = rule.conditionText
               ? rule.cssRules[0].selectorText
               : rule.selectorText
 
-            rule.score = getRuleScore(
+            const score = getRuleScore(
               renderer.ruleOrder,
               selectorText.split(CLASSNAME_REGEX)[1]
             )
+
+            if (score === 0) {
+              renderer.scoreIndex[nodeReference] = index
+            }
+
+            rule.score = score
           })
         }
       }

--- a/packages/fela-dom/src/dom/render.js
+++ b/packages/fela-dom/src/dom/render.js
@@ -7,6 +7,7 @@ import type { DOMRenderer } from '../../../../flowtypes/DOMRenderer'
 
 export default function render(renderer: DOMRenderer): void {
   if (!renderer.updateSubscription) {
+    renderer.scoreIndex = {}
     renderer.nodes = {}
 
     renderer.updateSubscription = createSubscription(renderer)

--- a/packages/fela/src/createRenderer.js
+++ b/packages/fela/src/createRenderer.js
@@ -63,6 +63,7 @@ export default function createRenderer(
     uniqueKeyframeIdentifier: 0,
 
     nodes: {},
+    scoreIndex: {},
     // use a flat cache object with pure string references
     // to achieve maximal lookup performance and memoization speed
     cache: {},


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guidelines at the bottom.
------------------------------------------->

## Description
This PR adds some further performance improvements for DOM rendering by caching the score=0 rule index to insert plain rules.

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

