### PR TITLE
fix(fela-plugin-extend): don't throw on undefined items in extend array

### DIFF
--- a/packages/fela-plugin-extend/src/__tests__/extend-test.js
+++ b/packages/fela-plugin-extend/src/__tests__/extend-test.js
@@ -156,6 +156,18 @@ describe('Extend plugin', () => {
     })
   })
 
+  it('should filter out null items in extend array', () => {
+    const base = {
+      color: 'blue',
+      extend: [{ backgroundColor: '#ccc' }, null],
+    }
+
+    expect(extend()(base)).toEqual({
+      color: 'blue',
+      backgroundColor: '#ccc',
+    })
+  })
+
   it('should not overwrite values with null or undefined', () => {
     const base = {
       color: 'blue',

--- a/packages/fela-plugin-extend/src/index.js
+++ b/packages/fela-plugin-extend/src/index.js
@@ -22,7 +22,10 @@ function removeUndefined(style: Object): Object {
 
 function extendStyle(style: Object, extension: Object): void {
   // extend conditional style objects
-  if (extension.hasOwnProperty('condition')) {
+  if (
+    extension &&
+    Object.prototype.hasOwnProperty.call(extension, 'condition')
+  ) {
     if (extension.condition) {
       // eslint-disable-next-line no-use-before-define
       assignStyle(style, extend(extension.style))


### PR DESCRIPTION
## Description
Fixes #657 where `fela-plugin-extend` would throw when the `extend` key in a style object was an array with a `null` or `undefined` item inside it.

Adds a test

## Packages

fela-plugin-extend


## Versioning

- [ ] Major
- [ ] Minor
- [x] Patch

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

