### PR TITLE
Fix styling non-standard pseudo elements

### DIFF
--- a/packages/fela-dom/src/dom/connection/insertRule.js
+++ b/packages/fela-dom/src/dom/connection/insertRule.js
@@ -32,7 +32,7 @@ export default function insertRule(
       if (renderer.scoreIndex[nodeReference] === undefined) {
         index = 0
       } else {
-        index = renderer.scoreIndex[nodeReference] + 1;
+        index = renderer.scoreIndex[nodeReference] + 1
       }
     } else {
       // we start iterating from the last score=0 entry
@@ -57,7 +57,7 @@ export default function insertRule(
     }
 
     if (score === 0) {
-      renderer.scoreIndex[nodeReference] = index;
+      renderer.scoreIndex[nodeReference] = index
     }
 
     cssRules[index].score = score

--- a/packages/fela-dom/src/dom/connection/insertRule.js
+++ b/packages/fela-dom/src/dom/connection/insertRule.js
@@ -30,11 +30,9 @@ export default function insertRule(
 
     if (score === 0) {
       if (renderer.scoreIndex[nodeReference] === undefined) {
-        renderer.scoreIndex[nodeReference] = 0
         index = 0
       } else {
-        ++renderer.scoreIndex[nodeReference]
-        index = renderer.scoreIndex[nodeReference]
+        index = renderer.scoreIndex[nodeReference] + 1;
       }
     } else {
       // we start iterating from the last score=0 entry
@@ -56,6 +54,10 @@ export default function insertRule(
       node.sheet.insertRule(cssSupportRule, index)
     } else {
       node.sheet.insertRule(cssRule, index)
+    }
+
+    if (score === 0) {
+      renderer.scoreIndex[nodeReference] = index;
     }
 
     cssRules[index].score = score


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guidelines at the bottom.
------------------------------------------->

## Description
This PR fixes an issue with styling pseudo-elements the browser does not understand. This includes vendor-specific elements such as `::-moz-progress-bar`.

The cached `scoreIndex` value would be increased but `insertRule` method would not add the rule. Any further rules would then result in an `IndexSizeError`.

## Packages
- fela-dom

## Versioning

- [ ] Major
- [ ] Minor
- [x] Patch

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

