### PR TITLE
fix(react-fela): add FelaTheme to typings

### DIFF
--- a/packages/react-fela/index.d.ts
+++ b/packages/react-fela/index.d.ts
@@ -21,6 +21,15 @@ declare module "react-fela" {
    */
   export class ThemeProvider extends React.Component<ThemeProviderProps, {}> { }
 
+  interface FelaThemeProps {
+    children: (theme: object) => React.ReactNode;
+  }
+
+  /**
+   * Fela Theme
+   */
+  export class FelaTheme extends React.Component<FelaThemeProps, {}> {}
+
   interface ProviderProps {
     renderer: object;
     mountNode?: any;
@@ -529,26 +538,26 @@ declare module "react-fela" {
       theme: T,
       as: keyof React.ReactHTML,
     }
-  
+
     export type StyleProps<T, P = {}> = { theme: T } & {
       [K in keyof P]?: P[K]
     }
-  
+
     export type StyleFunction<T, P = {}> = (styleProps: StyleProps<T, P>) => IStyle
-  
+
     export type FelaStyle<T, P = {}> = IStyle | StyleFunction<T, P> | Array<StyleFunction<T, P> | IStyle>
-  
+
     export interface WithStyle<T, P> {
       style: FelaStyle<T, P>
     }
-  
+
     interface FelaComponentProps<T, P = {}> {
       children?: ((renderProps: RenderProps<T>) => React.ReactNode) | React.ReactNode,
       customClass?: string,
       style: FelaStyle<T, P>,
       as?: keyof React.ReactHTML,
     }
-  
+
     export class FelaComponent<T, P = {}> extends React.Component<FelaComponentProps<T, P> & P> {
     }
 }


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guidelines at the bottom.
------------------------------------------->

## Description
Adds `FelaTheme` to typings, without the `render` prop as it was deprecated.
http://fela.js.org/docs/api/bindings/FelaTheme.html

## Packages
- `react-fela`

## Versioning

- [ ] Major
- [ ] Minor
- [x] Patch

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

Tested locally in our repo and works like a charm 🎉 

