### PR TITLE
Add Pseudo-Classes to IStyle TypeScript Definition

### DIFF
--- a/packages/fela/index.d.ts
+++ b/packages/fela/index.d.ts
@@ -49,7 +49,8 @@ declare module "fela" {
     devMode?: boolean;
   }
 
-  export interface IStyle extends CSS.Properties<string | number> {
+  type Psudos = { [P in CSS.SimplePseudos]?: CSS.Properties<string | number> }
+  export interface IStyle extends Psudos, CSS.Properties<string | number> {
     //TODO: add properties, missing in React.CSSProperties
   }
 


### PR DESCRIPTION
## Description
Adds pseudo-classes to the Fela `IStyle` TypeScript definition by following the example in the [usage](https://github.com/frenic/csstype#usage) section of [frenic/csstype](https://github.com/frenic/csstype).

## Example
Before, this change this would throw the TypeScript Error: `Object literal may only specify known properties, and '':focus'' does not exist in type 'IStyle'.`
```javascript
export const input = (): IStyle => ({
  backgroundColor: 'white',
  ':focus': {
    backgroundColor: 'blue',
  }
});
```

## Packages
List all packages that have been changed.

- fela

## Versioning

- [ ] Major
- [ ] Minor
- [x] Patch

## Checklist

#### Quality Assurance
- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)