### PR TITLE
pass theme with props when using useFela

### DIFF
--- a/packages/react-fela/src/useFela.js
+++ b/packages/react-fela/src/useFela.js
@@ -13,10 +13,15 @@ type HookInterface = {
 
 export default function useFela(props: Object = {}): HookInterface {
   const renderer = useContext(RendererContext)
-  const theme = useContext(ThemeContext)
+  const theme = useContext(ThemeContext) || {}
+
+  const propsWithTheme = {
+    ...props,
+    theme,
+  }
 
   function css(...rules: Array<Object | Function>) {
-    return renderer.renderRule(combineRules(...rules), props)
+    return renderer.renderRule(combineRules(...rules), propsWithTheme)
   }
 
   return {


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guidelines at the bottom.
------------------------------------------->

## Description
Passes the theme to props as well when using `useFela` together with rules.


## Packages
List all packages that have been changed.

- react-fela

## Versioning

I consider it a patch even though it might be considered Minor Major. The reason is that I believe it is a bug at first hand and should have been there all the time.

- [ ] Major
- [ ] Minor
- [x] Patch

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

