### PR TITLE
Theme-based bidi/rtl transformation

### DIFF
--- a/packages/fela-plugin-bidi/README.md
+++ b/packages/fela-plugin-bidi/README.md
@@ -75,6 +75,23 @@ const renderer = createRenderer({
 }
 ```
 
+## Theme-Based Mode
+Apart from enforcing either rtl or ltr all the time, one can also leverage a special `props.theme.direction` property to dynamically set the transformation mode. This is especially useful together with React to switch transformation for subtrees.
+
+```javascript
+const rule = () => ({
+  backgroundImage: 'logical url(/foo/bar/ste.png)',
+  cursor: 'start-resize',
+  float: 'end',
+  margin: 'logical 1px 2px 3px 4px',
+  paddingStart: 20,
+})
+
+// default
+renderer.renderRule(rule, { theme: { direction: 'ltr' }})
+renderer.renderRule(rule, { theme: { direction: 'rtl' }})
+```
+
 ## License
 Fela is licensed under the [MIT License](http://opensource.org/licenses/MIT).<br>
 Documentation is licensed under [Creative Common License](http://creativecommons.org/licenses/by/4.0/).<br>

--- a/packages/fela-plugin-bidi/src/__tests__/rtl-test.js
+++ b/packages/fela-plugin-bidi/src/__tests__/rtl-test.js
@@ -24,4 +24,15 @@ describe('Bidi plugin', () => {
       },
     })
   })
+
+  it('should use the theme.direction property', () => {
+    expect(
+      bidi('ltr')(style, undefined, undefined, { theme: { direction: 'rtl' } })
+    ).toEqual({
+      paddingRight: 20,
+      ':hover': {
+        backgroundImage: 'url(foo/rtl.png)',
+      },
+    })
+  })
 })

--- a/packages/fela-plugin-bidi/src/index.js
+++ b/packages/fela-plugin-bidi/src/index.js
@@ -1,6 +1,18 @@
 /* @flow */
 import transformStyle from 'bidi-css-js'
 
-export default function bidi(flowDirection: 'ltr' | 'rtl') {
-  return (style: Object) => transformStyle(style, flowDirection)
+import type { DOMRenderer } from '../../../flowtypes/DOMRenderer'
+import type { StyleType } from '../../../flowtypes/StyleType'
+
+export default function bidi(flowDirection: 'ltr' | 'rtl' = 'ltr') {
+  return (
+    style: Object,
+    type: StyleType,
+    renderer: DOMRenderer,
+    props: Object
+  ) =>
+    transformStyle(
+      style,
+      (props && props.theme && props.theme.direction) || flowDirection
+    )
 }

--- a/packages/fela-plugin-rtl/README.md
+++ b/packages/fela-plugin-rtl/README.md
@@ -44,6 +44,24 @@ const renderer = createRenderer({
 }
 ```
 
+## Theme-Based Mode
+Apart from enforcing rtl all the time, one can also leverage a special `props.theme.direction` property to enable/disable rtl transformation. This is especially useful together with React to disable transformation for subtrees.
+
+```javascript
+const rule = () => ({
+  paddingLeft: 20,
+  marginRight: '25px',
+  cursor: 'w-resize',
+  textShadow: 'red 2px 0'
+})
+
+// will be transformed
+renderer.renderRule(rule)
+
+// wont be transformed
+renderer.renderRule(rule, { theme: { direction: 'ltr' }})
+```
+
 ## License
 Fela is licensed under the [MIT License](http://opensource.org/licenses/MIT).<br>
 Documentation is licensed under [Creative Common License](http://creativecommons.org/licenses/by/4.0/).<br>

--- a/packages/fela-plugin-rtl/src/__tests__/rtl-test.js
+++ b/packages/fela-plugin-rtl/src/__tests__/rtl-test.js
@@ -16,4 +16,17 @@ describe('RTL plugin', () => {
       },
     })
   })
+
+  it('should check the theme.direction property', () => {
+    const style = {
+      paddingLeft: 20,
+      ':hover': {
+        marginRight: '25px',
+      },
+    }
+
+    expect(
+      rtl()(style, undefined, undefined, { theme: { direction: 'ltr' } })
+    ).toEqual(style)
+  })
 })

--- a/packages/fela-plugin-rtl/src/index.js
+++ b/packages/fela-plugin-rtl/src/index.js
@@ -1,6 +1,20 @@
 /* @flow */
 import transformStyle from 'rtl-css-js'
 
+import type { DOMRenderer } from '../../../flowtypes/DOMRenderer'
+import type { StyleType } from '../../../flowtypes/StyleType'
+
 export default function rtl() {
-  return transformStyle
+  return (
+    style: Object,
+    type: StyleType,
+    renderer: DOMRenderer,
+    props: Object
+  ) => {
+    if (props && props.theme && props.theme.direction === 'ltr') {
+      return style
+    }
+
+    return transformStyle(style)
+  }
 }


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guidelines at the bottom.
------------------------------------------->

## Description
Adds the ability to set the transformation mode for both fela-plugin-rtl and fela-plugin-bidi using a special theme property `theme.direction`.

## Example
See the plugin's README examples.

## Packages
List all packages that have been changed.

- fela-plugin-rtl
- fela-plugin-bidi

## Versioning
Minor

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

