### PR TITLE
fix(fela): get rid of const enum in typings

### DIFF
--- a/packages/fela/index.d.ts
+++ b/packages/fela/index.d.ts
@@ -1,5 +1,6 @@
 declare module "fela" {
   import * as CSS from 'csstype';
+  import { TRuleType, TKeyframeType, TFontType, TStaticType, TClearType } from 'fela-utils';
 
   export type TRuleProps = {};
   export type TRule<T = TRuleProps> = (props: T) => IStyle
@@ -9,14 +10,7 @@ declare module "fela" {
   type TPlugin = (style: IStyle) => IStyle; //http://fela.js.org/docs/advanced/Plugins.html
   type TEnhancer = (renderer: IRenderer) => IRenderer; //http://fela.js.org/docs/advanced/Enhancers.html
 
-  const enum TSubscribeMessageType {
-    rule = 'RULE',
-    staticObject = 'RULE',
-    keyframes = 'KEYFRAME',
-    fontFace = 'FONT',
-    staticString = 'STATIC',
-    clear = 'CLEAR'
-  }
+  type TSubscribeMessageType = TRuleType | TKeyframeType | TFontType | TStaticType | TClearType
 
   interface ISubscribeMessage {
     type: TSubscribeMessageType;
@@ -184,6 +178,20 @@ declare module "fela-statistics" {
   import { TEnhancer } from "fela";
 
   export default function(): TEnhancer;
+}
+
+declare module "fela-utils" {
+  export type TRuleType = "RULE"
+  export type TKeyframeType = "KEYFRAME"
+  export type TFontType = "FONT"
+  export type TStaticType = "STATIC"
+  export type TClearType = "CLEAR"
+
+  export const RULE_TYPE: TRuleType
+  export const KEYFRAME_TYPE: TKeyframeType
+  export const FONT_TYPE: TFontType
+  export const STATIC_TYPE: TStaticType
+  export const CLEAR_TYPE: TClearType
 }
 
 /**


### PR DESCRIPTION
## Description

Currently `fela` typings have a single use of `const enum` and it means that you cannot to build a project with `--isolatedModules`. See for more details: https://github.com/stardust-ui/react/issues/613

Actually, this change is very important because `const enum`s are not supported by `@babel/preset-typescript`, too.

I added typings for `fela-utils` as this package contains constants that can be used by consumers.

> You should use a union type of literals (string or number) instead.

https://github.com/Microsoft/TypeScript/issues/20703#issuecomment-362005736

## Packages
- `fela`

## Versioning
Actually, it's a breaking change that requires a major bump because you will not able to use `TSubscribeMessageType` as value.

## Before

```ts
import { TSubscribeMessageType } from 'fela'

const type = TSubscribeMessageType.rule
```

## After
```ts
import { RULE_TYPE } from 'fela-utils'

const type = RULE_TYPE 
```

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

