### PR TITLE
[fela-plugin-rtl] Ability to set default direction

### DIFF
--- a/packages/fela-plugin-bidi/README.md
+++ b/packages/fela-plugin-bidi/README.md
@@ -41,6 +41,12 @@ const renderer = createRenderer({
 })
 ```
 
+### Configuration
+##### Parameters
+| Parameter | Value | Default | Description |
+| --- | --- | --- | --- |
+| flowDirection | *("rtl" \| "ltr")* | `ltr` | The default flow direction |
+
 ## Example
 
 #### Input

--- a/packages/fela-plugin-rtl/README.md
+++ b/packages/fela-plugin-rtl/README.md
@@ -23,6 +23,14 @@ const renderer = createRenderer({
 })
 ```
 
+
+### Configuration
+##### Parameters
+| Parameter | Value | Default | Description |
+| --- | --- | --- | --- |
+| defaultDirection | *("rtl" \| "ltr")* | `rtl` | The default direction which can be useful if one is using the `theme.direction` option to dynamically toggle rtl transformation |
+
+
 ## Example
 
 #### Input

--- a/packages/fela-plugin-rtl/src/__tests__/rtl-test.js
+++ b/packages/fela-plugin-rtl/src/__tests__/rtl-test.js
@@ -17,6 +17,17 @@ describe('RTL plugin', () => {
     })
   })
 
+  it('should respect the default direction', () => {
+    const style = {
+      paddingLeft: 20,
+      ':hover': {
+        marginRight: '25px',
+      },
+    }
+
+    expect(rtl('ltr')(style)).toEqual(style)
+  })
+
   it('should check the theme.direction property', () => {
     const style = {
       paddingLeft: 20,
@@ -28,5 +39,23 @@ describe('RTL plugin', () => {
     expect(
       rtl()(style, undefined, undefined, { theme: { direction: 'ltr' } })
     ).toEqual(style)
+  })
+
+  it('should use theme.direction over default direction', () => {
+    const style = {
+      paddingLeft: 20,
+      ':hover': {
+        marginRight: '25px',
+      },
+    }
+
+    expect(
+      rtl('ltr')(style, undefined, undefined, { theme: { direction: 'rtl' } })
+    ).toEqual({
+      paddingRight: 20,
+      ':hover': {
+        marginLeft: '25px',
+      },
+    })
   })
 })

--- a/packages/fela-plugin-rtl/src/index.js
+++ b/packages/fela-plugin-rtl/src/index.js
@@ -4,17 +4,20 @@ import transformStyle from 'rtl-css-js'
 import type { DOMRenderer } from '../../../flowtypes/DOMRenderer'
 import type { StyleType } from '../../../flowtypes/StyleType'
 
-export default function rtl() {
+export default function rtl(defaultDirection: 'rtl' | 'ltr' = 'rtl') {
   return (
     style: Object,
     type: StyleType,
     renderer: DOMRenderer,
     props: Object
   ) => {
-    if (props && props.theme && props.theme.direction === 'ltr') {
-      return style
+    const direction =
+      (props && props.theme && props.theme.direction) || defaultDirection
+
+    if (direction === 'rtl') {
+      return transformStyle(style)
     }
 
-    return transformStyle(style)
+    return style
   }
 }


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guidelines at the bottom.
------------------------------------------->

## Description
Adds the ability to set a default direction when using fela-plugin-rtl in order to use the `theme.direction` approach for conditional rtl transformation.


## Packages
List all packages that have been changed.

- fela-plugin-rtl

## Versioning
Patch (as this should have already been part of the last minor)

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

