### PR TITLE
perf(useFela): optimize passing of theme & props

### DIFF
--- a/packages/react-fela/src/useFela.js
+++ b/packages/react-fela/src/useFela.js
@@ -15,6 +15,12 @@ export default function useFela(props: Object = {}): HookInterface {
   const renderer = useContext(RendererContext)
   const theme = useContext(ThemeContext) || {}
 
+  if (!renderer) {
+    throw new Error(
+      'The "useFela" hook can only be used  inside a "RendererProvider"'
+    )
+  }
+
   const propsWithTheme = { theme }
   if (props) Object.assign(propsWithTheme, props)
 

--- a/packages/react-fela/src/useFela.js
+++ b/packages/react-fela/src/useFela.js
@@ -15,10 +15,8 @@ export default function useFela(props: Object = {}): HookInterface {
   const renderer = useContext(RendererContext)
   const theme = useContext(ThemeContext) || {}
 
-  const propsWithTheme = {
-    ...props,
-    theme,
-  }
+  const propsWithTheme = { theme }
+  if (props) Object.assign(propsWithTheme, props)
 
   function css(...rules: Array<Object | Function>) {
     return renderer.renderRule(combineRules(...rules), propsWithTheme)


### PR DESCRIPTION
## Description

This pull requests makes the following suggestions

#### Optimizations

In many simple use cases, the `useFela` hook will be used without any props passed to it, and will only make the `theme` available to the rule callbacks in the returned `css` function. In light of that,
this commit makes two optimizations:

1. Only merge props into the object that is passed to `css`'s callbacks when props are actually passed.
2. Merge props into the `propsWithTheme` object using mutative `Object.assign`, as it is by far the most performant way of doing so. See: https://jsperf.com/object-assign-vs-spreading/3

These may seem like micro optimizations, but since useFela is a hot
path that could potentially run thousands of times, I think this is
of value in this case.

#### DX

The `useFela` hook now throws an error with a helpful message when it is used in a component that isn't a descendant of a `RendererProvider`


## Packages
react-fela

## Versioning
Patch

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

