### PR TITLE
feat(FelaComponent): Allow style prop with empty value

### DIFF
--- a/packages/fela-bindings/src/FelaComponentFactory.js
+++ b/packages/fela-bindings/src/FelaComponentFactory.js
@@ -34,12 +34,6 @@ export default function FelaComponentFactory(
       'The `render` prop in FelaComponent is deprecated. It will be removed in react-fela@11.0.0.\nPlease always use `children` instead. See http://fela.js.org/docs/api/bindings/fela-component'
     )
 
-    if (!style) {
-      throw new Error(
-        'A valid `style` prop must be passed to FelaComponent in order to render.\nSee http://fela.js.org/docs/api/bindings/fela-component'
-      )
-    }
-
     const renderFn = renderer =>
       createElement(FelaTheme, undefined, theme => {
         // TODO: could optimise perf by not calling combineRules if not neccessary

--- a/packages/fela-integration/src/jest-react-fela_react-fela/__tests__/FelaComponent-test.js
+++ b/packages/fela-integration/src/jest-react-fela_react-fela/__tests__/FelaComponent-test.js
@@ -219,4 +219,16 @@ describe('Using the FelaComponent component', () => {
       )
     ).toMatchSnapshot()
   })
+
+  it('should render without style', () => {
+    expect(
+      createSnapshot(
+        <FelaComponent>
+          {({ className }) => (
+            <div className={className}>I am an unstyled div</div>
+          )}
+        </FelaComponent>
+      )
+    ).toMatchSnapshot()
+  })
 })

--- a/packages/fela-integration/src/jest-react-fela_react-fela/__tests__/__snapshots__/FelaComponent-test.js.snap
+++ b/packages/fela-integration/src/jest-react-fela_react-fela/__tests__/__snapshots__/FelaComponent-test.js.snap
@@ -169,3 +169,10 @@ exports[`Using the FelaComponent component should render children using the corr
 <h1 className=a b>Hello World</h1>;
 "
 `;
+
+exports[`Using the FelaComponent component should render without style 1`] = `
+"
+
+<div className>I am an unstyled div</div>;
+"
+`;


### PR DESCRIPTION

## Description
Since v10,  FelaComponent throws if the `style` prop is `null` or `undefined`, which I think is wrong. 

It's quite an edge case, but sometimes one may want an element to only be styled under certain conditions, and have that be determined dynamically. 

The easiest and most straightforward way to do that is to pass `null` to `FelaComponent`'s style prop from the parent component.

By removing the check and `throw` statement, it works as expected, so I don't really see any benefit in having it there. It doesn't really add any DX value, and is overly restrictive

## Example
```jsx
function MaybeStyled({ style, children, }) {
  return (<FelaComponent style={style}>{children}</FelaComponent>);
}


<MaybeStyle style={null} /> // renders <div></div>
<MaybeStyle style={{ color: 'red', }} /> // renders <div class="a"></div>
```

## Packages
fela-bindings

- 

## Versioning
Patch

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

