### PR TITLE
dx(FelaComponent): warn when rendering with an empty style prop

### DIFF
--- a/packages/fela-bindings/src/FelaComponentFactory.js
+++ b/packages/fela-bindings/src/FelaComponentFactory.js
@@ -34,9 +34,16 @@ export default function FelaComponentFactory(
       'The `render` prop in FelaComponent is deprecated. It will be removed in react-fela@11.0.0.\nPlease always use `children` instead. See http://fela.js.org/docs/api/bindings/fela-component'
     )
 
-    const renderFn = renderer =>
-      createElement(FelaTheme, undefined, theme => {
-        // TODO: could optimise perf by not calling combineRules if not neccessary
+    const renderFn = renderer => {
+      if (renderer.devMode && style == null) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          '"FelaComponent" is being rendered without a style prop\nIf all you need is access to theme, try using "FelaTheme" or the "useFela" hook instead'
+        )
+      }
+
+      return createElement(FelaTheme, undefined, theme => {
+        // TODO: could optimize perf by not calling combineRules if not necessary
         const className = renderer.renderRule(combineRules(style), {
           ...otherProps,
           theme,
@@ -68,6 +75,7 @@ export default function FelaComponentFactory(
 
         return createElement(as, { className: cls }, children)
       })
+    }
 
     return createElement(RendererContext.Consumer, undefined, renderFn)
   }


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guidelines at the bottom.
------------------------------------------->

## Description
Log a warning to the console when `FelaComponent` is rendered with an empty (`undefined` or `null`) `style` prop.

This can be a valid use case, but in most cases it is just a mistake.

## Example

```javascript
// Better use <FelaTheme />
<FelaComponent>
  {({ theme, className, }) => (<p>Our primary color is {theme.primary}</p>)
</FelaComponent>
```

## Packages
fela-bindings

- 

## Versioning
Patch

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

