### PR TITLE
Enable better Webpack tree-shaking support

### DIFF
--- a/packages/fela-beautifier/package.json
+++ b/packages/fela-beautifier/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "sideEffects": false,
   "files": [
     "LICENSE",
     "README.md",

--- a/packages/fela-bindings/package.json
+++ b/packages/fela-bindings/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "sideEffects": false,
   "files": [
     "README.md",
     "lib/**",

--- a/packages/fela-codemods/package.json
+++ b/packages/fela-codemods/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "sideEffects": false,
   "files": [
     "LICENSE",
     "README.md",

--- a/packages/fela-dom/package.json
+++ b/packages/fela-dom/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "sideEffects": false,
   "files": [
     "LICENSE",
     "README.md",

--- a/packages/fela-enzyme/package.json
+++ b/packages/fela-enzyme/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "sideEffects": false,
   "files": [
     "LICENSE",
     "README.md",

--- a/packages/fela-identifier/package.json
+++ b/packages/fela-identifier/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "sideEffects": false,
   "files": [
     "LICENSE",
     "README.md",

--- a/packages/fela-integration/package.json
+++ b/packages/fela-integration/package.json
@@ -3,6 +3,7 @@
   "name": "fela-integration",
   "version": "10.2.1",
   "description": "Fela private intergration testing package",
+  "sideEffects": false,
   "dependencies": {
     "fela": "^10.2.1",
     "fela-monolithic": "^10.2.1",

--- a/packages/fela-layout-debugger/package.json
+++ b/packages/fela-layout-debugger/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "sideEffects": false,
   "files": [
     "LICENSE",
     "README.md",

--- a/packages/fela-logger/package.json
+++ b/packages/fela-logger/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "sideEffects": false,
   "files": [
     "LICENSE",
     "README.md",

--- a/packages/fela-monolithic/package.json
+++ b/packages/fela-monolithic/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "sideEffects": false,
   "files": [
     "LICENSE",
     "README.md",

--- a/packages/fela-native/package.json
+++ b/packages/fela-native/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "sideEffects": false,
   "files": [
     "LICENSE",
     "README.md",

--- a/packages/fela-perf/package.json
+++ b/packages/fela-perf/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "sideEffects": false,
   "files": [
     "LICENSE",
     "README.md",

--- a/packages/fela-plugin-bidi/package.json
+++ b/packages/fela-plugin-bidi/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "sideEffects": false,
   "files": [
     "LICENSE",
     "README.md",

--- a/packages/fela-plugin-custom-property/package.json
+++ b/packages/fela-plugin-custom-property/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "sideEffects": false,
   "files": [
     "LICENSE",
     "README.md",

--- a/packages/fela-plugin-embedded/package.json
+++ b/packages/fela-plugin-embedded/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "sideEffects": false,
   "files": [
     "LICENSE",
     "README.md",

--- a/packages/fela-plugin-extend/package.json
+++ b/packages/fela-plugin-extend/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "sideEffects": false,
   "files": [
     "LICENSE",
     "README.md",

--- a/packages/fela-plugin-fallback-value/package.json
+++ b/packages/fela-plugin-fallback-value/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "sideEffects": false,
   "files": [
     "LICENSE",
     "README.md",

--- a/packages/fela-plugin-friendly-pseudo-class/package.json
+++ b/packages/fela-plugin-friendly-pseudo-class/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "sideEffects": false,
   "files": [
     "LICENSE",
     "README.md",

--- a/packages/fela-plugin-important/package.json
+++ b/packages/fela-plugin-important/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "sideEffects": false,
   "files": [
     "LICENSE",
     "README.md",

--- a/packages/fela-plugin-isolation/package.json
+++ b/packages/fela-plugin-isolation/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "sideEffects": false,
   "files": [
     "LICENSE",
     "README.md",

--- a/packages/fela-plugin-logger/package.json
+++ b/packages/fela-plugin-logger/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "sideEffects": false,
   "files": [
     "LICENSE",
     "README.md",

--- a/packages/fela-plugin-named-keys/package.json
+++ b/packages/fela-plugin-named-keys/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "sideEffects": false,
   "files": [
     "LICENSE",
     "README.md",

--- a/packages/fela-plugin-native-media-query/package.json
+++ b/packages/fela-plugin-native-media-query/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "sideEffects": false,
   "files": [
     "LICENSE",
     "README.md",

--- a/packages/fela-plugin-placeholder-prefixer/package.json
+++ b/packages/fela-plugin-placeholder-prefixer/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "sideEffects": false,
   "files": [
     "LICENSE",
     "README.md",

--- a/packages/fela-plugin-prefixer/package.json
+++ b/packages/fela-plugin-prefixer/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "sideEffects": false,
   "files": [
     "LICENSE",
     "README.md",

--- a/packages/fela-plugin-rtl/package.json
+++ b/packages/fela-plugin-rtl/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "sideEffects": false,
   "files": [
     "LICENSE",
     "README.md",

--- a/packages/fela-plugin-simulate/package.json
+++ b/packages/fela-plugin-simulate/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "sideEffects": false,
   "files": [
     "LICENSE",
     "README.md",

--- a/packages/fela-plugin-unit/package.json
+++ b/packages/fela-plugin-unit/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "sideEffects": false,
   "files": [
     "LICENSE",
     "README.md",

--- a/packages/fela-plugin-validator/package.json
+++ b/packages/fela-plugin-validator/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "sideEffects": false,
   "files": [
     "LICENSE",
     "README.md",

--- a/packages/fela-preset-dev/package.json
+++ b/packages/fela-preset-dev/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "sideEffects": false,
   "files": [
     "LICENSE",
     "README.md",

--- a/packages/fela-preset-web/package.json
+++ b/packages/fela-preset-web/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "sideEffects": false,
   "files": [
     "LICENSE",
     "README.md",

--- a/packages/fela-statistics/package.json
+++ b/packages/fela-statistics/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "sideEffects": false,
   "files": [
     "LICENSE",
     "README.md",

--- a/packages/fela-tools/package.json
+++ b/packages/fela-tools/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "sideEffects": false,
   "files": [
     "LICENSE",
     "README.md",

--- a/packages/fela-utils/package.json
+++ b/packages/fela-utils/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "sideEffects": false,
   "files": [
     "LICENSE",
     "README.md",

--- a/packages/fela/package.json
+++ b/packages/fela/package.json
@@ -6,6 +6,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "sideEffects": false,
   "files": [
     "LICENSE",
     "README.md",

--- a/packages/inferno-fela/package.json
+++ b/packages/inferno-fela/package.json
@@ -6,6 +6,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "sideEffects": false,
   "files": [
     "LICENSE",
     "README.md",

--- a/packages/jest-fela-bindings/package.json
+++ b/packages/jest-fela-bindings/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "sideEffects": false,
   "files": [
     "LICENSE",
     "README.md",

--- a/packages/jest-inferno-fela/package.json
+++ b/packages/jest-inferno-fela/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "sideEffects": false,
   "files": [
     "LICENSE",
     "README.md",

--- a/packages/jest-preact-fela/package.json
+++ b/packages/jest-preact-fela/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "sideEffects": false,
   "files": [
     "LICENSE",
     "README.md",

--- a/packages/jest-react-fela/package.json
+++ b/packages/jest-react-fela/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "sideEffects": false,
   "files": [
     "LICENSE",
     "README.md",

--- a/packages/preact-fela/package.json
+++ b/packages/preact-fela/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "sideEffects": false,
   "files": [
     "LICENSE",
     "README.md",

--- a/packages/react-fela/package.json
+++ b/packages/react-fela/package.json
@@ -6,6 +6,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "sideEffects": false,
   "files": [
     "LICENSE",
     "README.md",


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guidelines at the bottom.
------------------------------------------->

## Description
This commit adds `sideEffects: false` to the `package.json` of every
package in the repository in order Webpack to eficiently be able to
tree-shake rexports.

See
https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free

## Example


## Packages
all

- 

## Versioning
Patch

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

