### PR TITLE
fix(renderer): apply `data-fela-id` always

### DIFF
--- a/packages/fela-dom/src/dom/__tests__/__snapshots__/rehydrate-test.js.snap
+++ b/packages/fela-dom/src/dom/__tests__/__snapshots__/rehydrate-test.js.snap
@@ -93,7 +93,7 @@ exports[`Rehydrating from DOM nodes should rehydrate with correct "rendererId" 1
 "<html>
 
 <head>
-  <style type=\\"text/css\\" data-fela-rehydration=\\"2\\" data-fela-type=\\"RULE\\">
+  <style type=\\"text/css\\" data-fela-rehydration=\\"2\\" data-fela-type=\\"RULE\\" data-fela-id=\\"\\">
     .a {
       color: yellow
     }

--- a/packages/fela-dom/src/dom/__tests__/__snapshots__/render-test.js.snap
+++ b/packages/fela-dom/src/dom/__tests__/__snapshots__/render-test.js.snap
@@ -4,7 +4,7 @@ exports[`render (development) should correctly sort rules 1`] = `
 "<html>
 
 <head>
-  <style data-fela-type=\\"RULE\\" type=\\"text/css\\">
+  <style data-fela-id=\\"\\" data-fela-type=\\"RULE\\" type=\\"text/css\\">
     .a {
       color: blue
     }
@@ -40,14 +40,14 @@ exports[`render (development) should create style nodes and render CSS rules 1`]
 "<html>
 
 <head>
-  <style data-fela-type=\\"FONT\\" type=\\"text/css\\">
+  <style data-fela-id=\\"\\" data-fela-type=\\"FONT\\" type=\\"text/css\\">
     @font-face {
       font-weight: 300;
       src: url('../Lato.ttf') format('truetype');
       font-family: \\"Lato\\"
     }
   </style>
-  <style data-fela-type=\\"KEYFRAME\\" type=\\"text/css\\">
+  <style data-fela-id=\\"\\" data-fela-type=\\"KEYFRAME\\" type=\\"text/css\\">
     @-webkit-keyframes k1 {
       0% {
         color: yellow
@@ -78,7 +78,7 @@ exports[`render (development) should create style nodes and render CSS rules 1`]
       }
     }
   </style>
-  <style data-fela-type=\\"RULE\\" type=\\"text/css\\">
+  <style data-fela-id=\\"\\" data-fela-type=\\"RULE\\" type=\\"text/css\\">
     .a {
       background-color: red
     }
@@ -98,7 +98,7 @@ exports[`render (development) should not overwrite rehydrated styles 1`] = `
 "<html>
 
 <head>
-  <style type=\\"text/css\\" data-fela-rehydration=\\"5\\" data-fela-type=\\"RULE\\">
+  <style type=\\"text/css\\" data-fela-rehydration=\\"5\\" data-fela-type=\\"RULE\\" data-fela-id=\\"\\">
     .b {
       color: yellow
     }
@@ -115,14 +115,14 @@ exports[`render (development) should not overwrite rehydrated styles 1`] = `
       color: red
     }
   </style>
-  <style type=\\"text/css\\" data-fela-rehydration=\\"5\\" data-fela-type=\\"RULE\\" data-fela-support=\\"true\\">
+  <style type=\\"text/css\\" data-fela-rehydration=\\"5\\" data-fela-type=\\"RULE\\" data-fela-id=\\"\\" data-fela-support=\\"true\\">
     @supports (display:flex) {
       .e {
         color: green
       }
     }
   </style>
-  <style type=\\"text/css\\" data-fela-rehydration=\\"5\\" data-fela-type=\\"RULE\\" media=\\"(max-width: 800px)\\">
+  <style type=\\"text/css\\" data-fela-rehydration=\\"5\\" data-fela-type=\\"RULE\\" data-fela-id=\\"\\" media=\\"(max-width: 800px)\\">
     .d {
       color: blue
     }
@@ -138,7 +138,7 @@ exports[`render (development) should not render multiple times 1`] = `
 "<html>
 
 <head>
-  <style data-fela-type=\\"RULE\\" type=\\"text/css\\">
+  <style data-fela-id=\\"\\" data-fela-type=\\"RULE\\" type=\\"text/css\\">
     .a {
       background-color: red
     }

--- a/packages/fela-dom/src/dom/connection/__tests__/__snapshots__/createNode-test.js.snap
+++ b/packages/fela-dom/src/dom/connection/__tests__/__snapshots__/createNode-test.js.snap
@@ -4,7 +4,7 @@ exports[`Creating a style node should have the correct attributes 1`] = `
 Object {
   "_media": undefined,
   "_support": undefined,
-  "html": "<style data-fela-type=\\"RULE\\" type=\\"text/css\\"></style>",
+  "html": "<style data-fela-id=\\"\\" data-fela-type=\\"RULE\\" type=\\"text/css\\"></style>",
 }
 `;
 
@@ -12,7 +12,7 @@ exports[`Creating a style node should have the correct attributes 2`] = `
 Object {
   "_media": "(min-width:300px)",
   "_support": undefined,
-  "html": "<style data-fela-type=\\"RULE\\" type=\\"text/css\\" media=\\"(min-width:300px)\\"></style>",
+  "html": "<style data-fela-id=\\"\\" data-fela-type=\\"RULE\\" type=\\"text/css\\" media=\\"(min-width:300px)\\"></style>",
 }
 `;
 
@@ -20,7 +20,7 @@ exports[`Creating a style node should have the correct attributes 3`] = `
 Object {
   "_media": undefined,
   "_support": "(display:flex)",
-  "html": "<style data-fela-type=\\"RULE\\" type=\\"text/css\\" data-fela-support=\\"true\\"></style>",
+  "html": "<style data-fela-id=\\"\\" data-fela-type=\\"RULE\\" type=\\"text/css\\" data-fela-support=\\"true\\"></style>",
 }
 `;
 
@@ -28,7 +28,7 @@ exports[`Creating a style node should have the correct attributes 4`] = `
 Object {
   "_media": "(min-width:300px)",
   "_support": "(display:flex)",
-  "html": "<style data-fela-type=\\"RULE\\" type=\\"text/css\\" data-fela-support=\\"true\\" media=\\"(min-width:300px)\\"></style>",
+  "html": "<style data-fela-id=\\"\\" data-fela-type=\\"RULE\\" type=\\"text/css\\" data-fela-support=\\"true\\" media=\\"(min-width:300px)\\"></style>",
 }
 `;
 
@@ -36,16 +36,16 @@ exports[`Creating a style node should have the correct attributes 5`] = `
 Object {
   "_media": undefined,
   "_support": undefined,
-  "html": "<style data-fela-type=\\"RULE\\" type=\\"text/css\\" data-fela-id=\\"ID\\"></style>",
+  "html": "<style data-fela-id=\\"ID\\" data-fela-type=\\"RULE\\" type=\\"text/css\\"></style>",
 }
 `;
 
 exports[`Creating a style node should respect the correct order 1`] = `
 "<head>
-  <style data-fela-type=\\"STATIC\\" type=\\"text/css\\"></style>
-  <style data-fela-type=\\"KEYFRAME\\" type=\\"text/css\\"></style>
-  <style data-fela-type=\\"RULE\\" type=\\"text/css\\"></style>
-  <style data-fela-type=\\"RULE\\" type=\\"text/css\\" media=\\"(min-width:300px)\\"></style>
-  <style data-fela-type=\\"RULE\\" type=\\"text/css\\" data-fela-support=\\"true\\" media=\\"(min-width:300px)\\"></style>
+  <style data-fela-id=\\"\\" data-fela-type=\\"STATIC\\" type=\\"text/css\\"></style>
+  <style data-fela-id=\\"\\" data-fela-type=\\"KEYFRAME\\" type=\\"text/css\\"></style>
+  <style data-fela-id=\\"\\" data-fela-type=\\"RULE\\" type=\\"text/css\\"></style>
+  <style data-fela-id=\\"\\" data-fela-type=\\"RULE\\" type=\\"text/css\\" media=\\"(min-width:300px)\\"></style>
+  <style data-fela-id=\\"\\" data-fela-type=\\"RULE\\" type=\\"text/css\\" data-fela-support=\\"true\\" media=\\"(min-width:300px)\\"></style>
 </head>"
 `;

--- a/packages/fela-dom/src/dom/connection/__tests__/__snapshots__/createSubscription-test.js.snap
+++ b/packages/fela-dom/src/dom/connection/__tests__/__snapshots__/createSubscription-test.js.snap
@@ -4,7 +4,7 @@ exports[`Subscribing to the DOM should clear all DOM nodes 1`] = `"<head></head>
 
 exports[`Subscribing to the DOM should correctly recreate nodes after clean 1`] = `
 "<head>
-  <style data-fela-type=\\"KEYFRAME\\" type=\\"text/css\\">
+  <style data-fela-id=\\"\\" data-fela-type=\\"KEYFRAME\\" type=\\"text/css\\">
     @-webkit-keyframes k1 {
       from {
         color: red
@@ -35,17 +35,17 @@ exports[`Subscribing to the DOM should correctly recreate nodes after clean 1`] 
       }
     }
   </style>
-  <style data-fela-type=\\"RULE\\" type=\\"text/css\\">
+  <style data-fela-id=\\"\\" data-fela-type=\\"RULE\\" type=\\"text/css\\">
     .a {
       color: blue
     }
   </style>
-  <style data-fela-type=\\"RULE\\" type=\\"text/css\\" media=\\"(min-width: 300px)\\">
+  <style data-fela-id=\\"\\" data-fela-type=\\"RULE\\" type=\\"text/css\\" media=\\"(min-width: 300px)\\">
     .b {
       color: red
     }
   </style>
-  <style data-fela-type=\\"RULE\\" type=\\"text/css\\" media=\\"(min-width: 300px) and (max-height: 500px)\\">
+  <style data-fela-id=\\"\\" data-fela-type=\\"RULE\\" type=\\"text/css\\" media=\\"(min-width: 300px) and (max-height: 500px)\\">
     .c {
       color: yellow
     }
@@ -55,7 +55,7 @@ exports[`Subscribing to the DOM should correctly recreate nodes after clean 1`] 
 
 exports[`Subscribing to the DOM should render keyframes to a DOM node 1`] = `
 "<head>
-  <style data-fela-type=\\"KEYFRAME\\" type=\\"text/css\\">
+  <style data-fela-id=\\"\\" data-fela-type=\\"KEYFRAME\\" type=\\"text/css\\">
     @-webkit-keyframes k1 {
       from {
         color: red
@@ -91,29 +91,29 @@ exports[`Subscribing to the DOM should render keyframes to a DOM node 1`] = `
 
 exports[`Subscribing to the DOM should render media rules and support rules to single DOM nodes (devMode) 1`] = `
 "<head>
-  <style data-fela-type=\\"RULE\\" type=\\"text/css\\">
+  <style data-fela-id=\\"\\" data-fela-type=\\"RULE\\" type=\\"text/css\\">
     .a {
       color: blue
     }
   </style>
-  <style data-fela-type=\\"RULE\\" type=\\"text/css\\" data-fela-support=\\"true\\"></style>
-  <style data-fela-type=\\"RULE\\" type=\\"text/css\\" media=\\"(min-width: 300px)\\">
+  <style data-fela-id=\\"\\" data-fela-type=\\"RULE\\" type=\\"text/css\\" data-fela-support=\\"true\\"></style>
+  <style data-fela-id=\\"\\" data-fela-type=\\"RULE\\" type=\\"text/css\\" media=\\"(min-width: 300px)\\">
     .c {
       color: red
     }
   </style>
-  <style data-fela-type=\\"RULE\\" type=\\"text/css\\" media=\\"(min-width: 300px) and (max-height: 500px)\\">
+  <style data-fela-id=\\"\\" data-fela-type=\\"RULE\\" type=\\"text/css\\" media=\\"(min-width: 300px) and (max-height: 500px)\\">
     .d {
       color: yellow
     }
   </style>
-  <style data-fela-type=\\"RULE\\" type=\\"text/css\\" data-fela-support=\\"true\\" media=\\"(min-width: 300px) and (max-height: 500px)\\"></style>
+  <style data-fela-id=\\"\\" data-fela-type=\\"RULE\\" type=\\"text/css\\" data-fela-support=\\"true\\" media=\\"(min-width: 300px) and (max-height: 500px)\\"></style>
 </head>"
 `;
 
 exports[`Subscribing to the DOM should render rules to a DOM node 1`] = `
 "<head>
-  <style data-fela-type=\\"RULE\\" type=\\"text/css\\">
+  <style data-fela-id=\\"\\" data-fela-type=\\"RULE\\" type=\\"text/css\\">
     .a {
       background-color: red
     }
@@ -131,7 +131,7 @@ exports[`Subscribing to the DOM should render rules to a DOM node 1`] = `
 
 exports[`Subscribing to the DOM should render static styles to a DOM node 1`] = `
 "<head>
-  <style data-fela-type=\\"STATIC\\" type=\\"text/css\\">
+  <style data-fela-id=\\"\\" data-fela-type=\\"STATIC\\" type=\\"text/css\\">
     body,
     html {
       background-color: red;

--- a/packages/fela-dom/src/dom/connection/__tests__/queryNode-test.js
+++ b/packages/fela-dom/src/dom/connection/__tests__/queryNode-test.js
@@ -4,9 +4,9 @@ import queryNode from '../queryNode'
 
 it('should not query nodes with media attributes if media is not defined', () => {
   const nodeInvalid =
-    '<style data-fela-type="RULE" type="text/css" media="screen and (min-width: 1280px)">.b{color: blue}</style>'
+    '<style data-fela-id="" data-fela-type="RULE" type="text/css" media="screen and (min-width: 1280px)">.b{color: blue}</style>'
   const nodeValid =
-    '<style data-fela-type="RULE" type="text/css">.a{color: red}</style>'
+    '<style data-fela-id="" data-fela-type="RULE" type="text/css">.a{color: red}</style>'
 
   document.head.innerHTML = nodeInvalid + nodeValid
 
@@ -15,9 +15,9 @@ it('should not query nodes with media attributes if media is not defined', () =>
 
 it('should not query nodes with support attributes if support is not defined', () => {
   const nodeInvalid =
-    '<style data-fela-type="RULE" type="text/css" data-fela-support="true">.b{color: blue}</style>'
+    '<style data-fela-id="" data-fela-type="RULE" type="text/css" data-fela-support="true">.b{color: blue}</style>'
   const nodeValid =
-    '<style data-fela-type="RULE" type="text/css">.a{color: red}</style>'
+    '<style data-fela-id="" data-fela-type="RULE" type="text/css">.a{color: red}</style>'
 
   document.head.innerHTML = nodeInvalid + nodeValid
 

--- a/packages/fela-dom/src/dom/connection/createNode.js
+++ b/packages/fela-dom/src/dom/connection/createNode.js
@@ -12,12 +12,9 @@ export default function createNode(
   const head = document.head || {}
 
   const node = document.createElement('style')
+  node.setAttribute('data-fela-id', id)
   node.setAttribute('data-fela-type', type)
   node.type = 'text/css'
-
-  if (id.length > 0) {
-    node.setAttribute('data-fela-id', id)
-  }
 
   if (support) {
     node.setAttribute('data-fela-support', 'true')

--- a/packages/fela-dom/src/dom/connection/queryNode.js
+++ b/packages/fela-dom/src/dom/connection/queryNode.js
@@ -5,7 +5,7 @@ export default function queryNode(
   { type, media, support }: NodeAttributes,
   id?: string = ''
 ): ?Object {
-  const idQuery = id.length > 0 ? `[data-fela-id="${id}"]` : ''
+  const idQuery = `[data-fela-id="${id}"]`
   const mediaQuery = media ? `[media="${media}"]` : ':not([media])'
   const supportQuery = support
     ? '[data-fela-support="true"]'

--- a/packages/fela-dom/src/dom/rehydrate.js
+++ b/packages/fela-dom/src/dom/rehydrate.js
@@ -17,10 +17,7 @@ const CLASSNAME_REGEX = /[.][a-z0-9_-]*/gi
 export default function rehydrate(renderer: DOMRenderer): void {
   render(renderer)
 
-  const idQuery =
-    renderer.rendererId.length > 0
-      ? `[data-fela-id="${renderer.rendererId}"]`
-      : ''
+  const idQuery = `[data-fela-id="${renderer.rendererId}"]`
 
   arrayEach(document.querySelectorAll(`[data-fela-type]${idQuery}`), node => {
     const rehydrationAttribute =

--- a/packages/fela-dom/src/server/__tests__/__snapshots__/renderToMarkup-test.js.snap
+++ b/packages/fela-dom/src/server/__tests__/__snapshots__/renderToMarkup-test.js.snap
@@ -13,7 +13,7 @@ exports[`Rendering to HTML markup handles \`rendererId\` 1`] = `
 `;
 
 exports[`Rendering to HTML markup should correctly sort rules 1`] = `
-"<style type=\\"text/css\\" data-fela-rehydration=\\"3\\" data-fela-type=\\"RULE\\">
+"<style type=\\"text/css\\" data-fela-rehydration=\\"3\\" data-fela-type=\\"RULE\\" data-fela-id=\\"\\">
     .a:hover {
         color: red
     }
@@ -29,7 +29,7 @@ exports[`Rendering to HTML markup should correctly sort rules 1`] = `
 `;
 
 exports[`Rendering to HTML markup should return a single HTML markup string 1`] = `
-"<style type=\\"text/css\\" data-fela-rehydration=\\"6\\" data-fela-type=\\"STATIC\\">
+"<style type=\\"text/css\\" data-fela-rehydration=\\"6\\" data-fela-type=\\"STATIC\\" data-fela-id=\\"\\">
     * {
         box-sizing: border-box
     }
@@ -38,12 +38,12 @@ exports[`Rendering to HTML markup should return a single HTML markup string 1`] 
         display: flex
     }
 </style>
-<style type=\\"text/css\\" data-fela-rehydration=\\"6\\" data-fela-type=\\"RULE\\">
+<style type=\\"text/css\\" data-fela-rehydration=\\"6\\" data-fela-type=\\"RULE\\" data-fela-id=\\"\\">
     .a {
         color: red
     }
 </style>
-<style type=\\"text/css\\" data-fela-rehydration=\\"6\\" data-fela-type=\\"RULE\\" data-fela-support=\\"true\\">
+<style type=\\"text/css\\" data-fela-rehydration=\\"6\\" data-fela-type=\\"RULE\\" data-fela-id=\\"\\" data-fela-support=\\"true\\">
     @supports (display:flex) {
         .b {
             color: yellow
@@ -56,12 +56,12 @@ exports[`Rendering to HTML markup should return a single HTML markup string 1`] 
         }
     }
 </style>
-<style type=\\"text/css\\" data-fela-rehydration=\\"6\\" data-fela-type=\\"RULE\\" media=\\"(min-height: 300px)\\">
+<style type=\\"text/css\\" data-fela-rehydration=\\"6\\" data-fela-type=\\"RULE\\" data-fela-id=\\"\\" media=\\"(min-height: 300px)\\">
     .d {
         color: blue
     }
 </style>
-<style type=\\"text/css\\" data-fela-rehydration=\\"6\\" data-fela-type=\\"RULE\\" data-fela-support=\\"true\\" media=\\"(min-height: 300px)\\">
+<style type=\\"text/css\\" data-fela-rehydration=\\"6\\" data-fela-type=\\"RULE\\" data-fela-id=\\"\\" data-fela-support=\\"true\\" media=\\"(min-height: 300px)\\">
     @supports (display:flex) {
         .e {
             color: green

--- a/packages/fela-dom/src/server/createStyleTagMarkup.js
+++ b/packages/fela-dom/src/server/createStyleTagMarkup.js
@@ -9,8 +9,7 @@ export default function createStyleTagMarkup(
   rehydrationIndex: number = -1,
   support: boolean = false
 ): string {
-  const idAttribute =
-    rendererId.length > 0 ? ` data-fela-id="${rendererId}"` : ''
+  const idAttribute = ` data-fela-id="${rendererId}"`
   const mediaAttribute = media.length > 0 ? ` media="${media}"` : ''
   const supportAttribute = support ? ' data-fela-support="true"' : ''
 


### PR DESCRIPTION
## Description
We should always add `data-renderer-id` 🤔 

## Example
Easiest repro with broken styles in `devMode` (#664): https://codesandbox.io/s/2zz49q92xj
It will be produced when a renderer with defined `rendererId` will be first.

```js
const ltrSelector = '[data-fela-type="RULE"][data-fela-id="rtl"]:not([data-fela-support="true"]):not([media])'
const rtlSelector = '[data-fela-type="RULE"]:not([data-fela-support="true"]):not([media])'

console.log(document.querySelector(ltrSelector) === document.querySelector(rtlSelector)) // true
```

After this fix we will add `data-fela-id` to all nodes:

```js
const firstSelector = '[data-fela-type="RULE"][data-fela-id=""]:not([data-fela-support="true"]):not([media])'
const secondSelector = '[data-fela-type="RULE"][data-fela-id="rtl"]:not([data-fela-support="true"]):not([media])'

console.log(document.querySelector(ltrSelector) === document.querySelector(rtlSelector)) // false
```

## Packages
List all packages that have been changed.
-  fela-dom

## Versioning
Patch

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

