### PR TITLE
Adding lost ability to auto-merge & overwrite themes

### DIFF
--- a/packages/fela-bindings/src/ThemeProviderFactory.js
+++ b/packages/fela-bindings/src/ThemeProviderFactory.js
@@ -5,26 +5,20 @@ export default function ThemeProviderFactory(
   BaseComponent: any,
   ThemeContext: any,
   createElement: Function,
-  renderChildren: Function,
-  statics?: Object
+  renderChildren: Function
 ): any {
-  class ThemeProvider extends BaseComponent {
-    render(): Object {
-      return createElement(
+  return function ThemeProvider({ theme = {}, overwrite = false, children }) {
+    return createElement(ThemeContext.Consumer, null, previousTheme =>
+      createElement(
         ThemeContext.Provider,
         {
-          value: this.props.theme,
+          value:
+            !overwrite && previousTheme
+              ? { ...previousTheme, ...theme }
+              : theme,
         },
-        renderChildren(this.props.children)
+        renderChildren(children)
       )
-    }
+    )
   }
-
-  if (statics) {
-    objectEach(statics, (value, key) => {
-      ThemeProvider[key] = value
-    })
-  }
-
-  return ThemeProvider
 }

--- a/packages/fela-integration/src/jest-react-fela_react-fela/__tests__/ThemeProviderFactory-test.js
+++ b/packages/fela-integration/src/jest-react-fela_react-fela/__tests__/ThemeProviderFactory-test.js
@@ -15,4 +15,28 @@ describe('Using the ThemeProvider', () => {
 
     expect(snapshot).toMatchSnapshot()
   })
+
+  it('should merge theme objects', () => {
+    const snapshot = createSnapshot(
+      <ThemeProvider theme={{ color: 'red' }}>
+        <ThemeProvider theme={{ backgroundColor: 'blue' }}>
+          <FelaTheme>{theme => <div>{JSON.stringify(theme)}</div>}</FelaTheme>
+        </ThemeProvider>
+      </ThemeProvider>
+    )
+
+    expect(snapshot).toMatchSnapshot()
+  })
+
+  it('should overwrite theme objects', () => {
+    const snapshot = createSnapshot(
+      <ThemeProvider theme={{ color: 'red' }}>
+        <ThemeProvider overwrite theme={{ backgroundColor: 'blue' }}>
+          <FelaTheme>{theme => <div>{JSON.stringify(theme)}</div>}</FelaTheme>
+        </ThemeProvider>
+      </ThemeProvider>
+    )
+
+    expect(snapshot).toMatchSnapshot()
+  })
 })

--- a/packages/fela-integration/src/jest-react-fela_react-fela/__tests__/__snapshots__/ThemeProviderFactory-test.js.snap
+++ b/packages/fela-integration/src/jest-react-fela_react-fela/__tests__/__snapshots__/ThemeProviderFactory-test.js.snap
@@ -1,5 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Using the ThemeProvider should merge theme objects 1`] = `
+"
+
+<div>
+  {{}color:red,backgroundColor:blue{}}
+</div>;
+"
+`;
+
+exports[`Using the ThemeProvider should overwrite theme objects 1`] = `
+"
+
+<div>
+  {{}backgroundColor:blue{}}
+</div>;
+"
+`;
+
 exports[`Using the ThemeProvider should pass the theme to rule props 1`] = `
 "
 


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guidelines at the bottom.
------------------------------------------->

## Description
This PR simply reimplements the old behaviour that was lost when moving on to the new context API. I would consider that a bug and thus just a patch release.

## Packages
List all packages that have been changed.

- fela-bindings
- react-fela
- preact-fela
- inferno-fela

## Versioning
Patch 

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [ ] The code was formatted using Prettier (`yarn run format`)
- [ ] The code has no linting errors (`yarn run lint`)
- [ ] All tests are passing (`yarn run test`) 
- [ ] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [ ] Tests have been added/updated
- [ ] Documentation has been added/updated
- [ ] My changes have proper flow-types

