### PR TITLE
Update plugin-isolation's README.md - avoids misuse

### DIFF
--- a/packages/fela-plugin-isolation/README.md
+++ b/packages/fela-plugin-isolation/README.md
@@ -4,6 +4,8 @@
 
 Adds style isolation to every rule by attaching `all: initial` to every class.
 
+*If you just have classname collisions, please take a look at [the advanced Renderer configuration](https://fela.js.org/docs/advanced/RendererConfiguration.html) first.*
+
 ## Installation
 ```sh
 yarn add fela-plugin-isolation


### PR DESCRIPTION
Added a warning line, supposed to avoid misuse and point to the main documentation, that could be partially overlooked while setting up.

Closes https://github.com/rofrischmann/fela/issues/688
