### PR TITLE
Fix FelaRenderer TS type extending React.ComponentType

### DIFF
--- a/packages/react-fela/index.d.ts
+++ b/packages/react-fela/index.d.ts
@@ -565,7 +565,7 @@ declare module "react-fela" {
     /**
      * Fela Renderer
      */
-    export class FelaRenderer extends React.ComponentType<React.ConsumerProps<IRenderer>> {}
+    export class FelaRenderer extends React.Component<React.ConsumerProps<IRenderer>> {}
 
     export interface FelaHookProps<Theme> {
       css: (style: IStyle) => string,


### PR DESCRIPTION
## Description
ComponentType is a type and interfaces can't extend types, I assume this is supposed to be Component as that is what React classes extend. This causes a build failure for me.

## Packages
List all packages that have been changed.

- react-fela

## Versioning
Patch

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [ ] The code was formatted using Prettier (`yarn run format`)
- [ ] The code has no linting errors (`yarn run lint`)
- [ ] All tests are passing (`yarn run test`) 
- [ ] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rofrischmann/fela/692)
<!-- Reviewable:end -->
