### PR TITLE
Typescript support: useFela with props + css with varags params

### DIFF
--- a/packages/react-fela/index.d.ts
+++ b/packages/react-fela/index.d.ts
@@ -535,6 +535,11 @@ declare module "react-fela" {
     export function createComponentWithProxy<Props, Theme = any>(style: Style<Props>, base: "use", passThroughProps?: PassThroughProps<Props>): FelaSvgComponent<Props, SVGElement, Theme>;
     export function createComponentWithProxy<Props, Theme = any>(style: Style<Props>, base: "view", passThroughProps?: PassThroughProps<Props>): FelaSvgComponent<Props, SVGElement, Theme>;
 
+    /**
+     * Fela Renderer
+     */
+    export class FelaRenderer extends React.Component<React.ConsumerProps<IRenderer>> {}
+
     export const RendererContext: React.Context<IRenderer>
 
     interface RenderProps<T> {
@@ -565,17 +570,15 @@ declare module "react-fela" {
     export class FelaComponent<T, P = {}> extends React.Component<FelaComponentProps<T, P> & P> {
     }
 
+    export type CssFelaStyle<T, P> = IStyle | StyleFunction<T, P>
 
-    /**
-     * Fela Renderer
-     */
-    export class FelaRenderer extends React.Component<React.ConsumerProps<IRenderer>> {}
+    export type CssFunction<T, P> = (...style: CssFelaStyle<T, P>[]) => string
 
-    export interface FelaHookProps<Theme> {
-      css: (style: IStyle) => string,
-      theme: Theme,
+    export interface FelaHookProps<T, P> {
+      css: CssFunction<T, P>,
+      theme: T,
       renderer: IRenderer,
     }
 
-    export function useFela<Theme = {}>(): FelaHookProps<Theme>
+    export function useFela<T = {}, P = {}>(props?: P): FelaHookProps<T, P>
 }


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guidelines at the bottom.
------------------------------------------->

## Description
As @marcneander pointed out in #676, useFela does not cover passing properties. Based on http://fela.js.org/docs/api/bindings/useFela.html this PR contains following improvements:
* passing props to useFela
* passing style as varargs to the css function

## Example
See https://github.com/Indoqa/indoqa-react/blob/f8a08962ce3d854584088958e4730c901403b04c/packages/style-system-demo/src/fela/FelaHookSamples.tsx for all supported useFela usages.

```javascript
// your code 
```

## Packages
List all packages that have been changed.

- 

## Versioning
None / Patch / Minor / Major

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [ ] The code was formatted using Prettier (`yarn run format`)
- [ ] The code has no linting errors (`yarn run lint`)
- [ ] All tests are passing (`yarn run test`) 
- [ ] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [ ] Tests have been added/updated
- [ ] Documentation has been added/updated
- [ ] My changes have proper flow-types

