### PR TITLE
Sort styles’ keys before rendering class names

### DIFF
--- a/packages/fela/src/__tests__/sortObjectKeys-test.js
+++ b/packages/fela/src/__tests__/sortObjectKeys-test.js
@@ -1,0 +1,10 @@
+import sortObjectKeys from '../sortObjectKeys'
+
+describe('Sorting object keys', () => {
+  it('should sort keys in an object', () => {
+    const input = { b: 2, a: 1 }
+
+    expect(JSON.stringify(input)).not.toEqual('{"a":1,"b":2}')
+    expect(JSON.stringify(sortObjectKeys(input))).toEqual('{"a":1,"b":2}')
+  })
+})

--- a/packages/fela/src/createRenderer.js
+++ b/packages/fela/src/createRenderer.js
@@ -2,6 +2,7 @@
 import cssifyDeclaration from 'css-in-js-utils/lib/cssifyDeclaration'
 import arrayEach from 'fast-loops/lib/arrayEach'
 import isPlainObject from 'isobject'
+import sortObjectKeys from './sortObjectKeys'
 
 import {
   generateCombinedMediaQuery,
@@ -201,9 +202,10 @@ export default function createRenderer(
       support: string = ''
     ): string {
       let classNames = _className ? ` ${_className}` : ''
+      let sortedStyles = sortObjectKeys(style)
 
-      for (const property in style) {
-        const value = style[property]
+      for (const property in sortedStyles) {
+        const value = sortedStyles[property]
 
         if (isPlainObject(value)) {
           if (isNestedSelector(property)) {

--- a/packages/fela/src/sortObjectKeys.js
+++ b/packages/fela/src/sortObjectKeys.js
@@ -1,0 +1,17 @@
+/* @flow */
+import arrayReduce from 'fast-loops/lib/arrayReduce'
+
+export default function sortObjectKeys(input: Object): Object {
+  const keys = Object.keys(input)
+  const sortedKeys = keys.sort((a, b) => a.localeCompare(b))
+
+  return arrayReduce(
+    sortedKeys,
+    (output, key) => {
+      output[key] = input[key]
+
+      return output
+    },
+    {}
+  )
+}


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guidelines at the bottom.
------------------------------------------->

## Description

There is an issue with server-side rendering due to keys being sorted differently on Node and the client (non-Blink based). This pull-request intends to sort object keys before outputting to class names to avoid that React mismatch.

## Packages

- fela@10.2.4

## Versioning

Patch

## Checklist

#### Quality Assurance


- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [ ] All tests are passing (`yarn run test`) 
  Some tests are not passing but they don’t appear to be related to my changes. 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

