### PR TITLE
feat(renderer): add `targetDocument` option

### DIFF
--- a/docs/advanced/RendererConfiguration.md
+++ b/docs/advanced/RendererConfiguration.md
@@ -13,6 +13,7 @@ We might introduce more configuration options with future releases, so be sure t
 | enhancers  | *(Array?)* |  |  A list of [enhancers](../advanced/Enhancers.md) to enhance the renderer
 | mediaQueryOrder | *(Array?)* |  | An explicit order in which `@media` queries are rendered |
 | rendererId | *(string?)* |  | An optional unique identifier that will prefix your animation names and will be added as the value of a `data-fela-id` attribute on `<style>` nodes. An example use case: the recommended way is to have only one renderer, but there are some specific cases when you will need to have multiple renderers. This option allows you avoid conflicts in generated CSS rules via prefixing animation names and separated `<style>` tags. |
+| targetDocument | *(Document?)* | document | Allows to pass you a custom document to insert style rules, useful when you're are rendering to child windows. 
 | supportQueryOrder | *(Array?)* |  | An explicit order in which `@supports` queries are rendered |
 | selectorPrefix | *(string?)* |  | Prepend a static prefix to every generated class and keyframe. It must only consist of `a-zA-Z0-9-_` and start with `a-zA-Z_`. |
 | filterClassName | *(Function?)* | `cls => cls.indexOf('ad') !== -1` | Filter-function to filter used class names |

--- a/flowtypes/DOMRenderer.js
+++ b/flowtypes/DOMRenderer.js
@@ -6,6 +6,7 @@ export type DOMRenderer = {
   mediaQueryOrder: Array<string>,
   rendererId: string,
   selectorPrefix: string,
+  targetDocument: Document,
   filterClassName: Function,
   listeners: Array<Function>,
   uniqueRuleIdentifier: number,
@@ -29,6 +30,7 @@ export type DOMRendererConfig = {
   mediaQueryOrder?: Array<string>,
   rendererId?: string,
   selectorPrefix?: string,
+  targetDocument?: Document,
   filterClassName?: Function,
   devMode?: boolean,
 }

--- a/packages/fela-dom/src/dom/connection/__tests__/createNode-test.js
+++ b/packages/fela-dom/src/dom/connection/__tests__/createNode-test.js
@@ -17,7 +17,7 @@ describe('Creating a style node', () => {
     const getHTML = (media, support, rendererId = '') => ({
       _media: media,
       _support: support,
-      html: createNode({}, 0, { type: RULE_TYPE, media, support }, rendererId)
+      html: createNode({}, 0, { type: RULE_TYPE, media, support }, document, rendererId)
         .outerHTML,
     })
 
@@ -32,7 +32,7 @@ describe('Creating a style node', () => {
     const nodes = {}
 
     function createAndAdd(score, attributes) {
-      const node = createNode(nodes, score, attributes)
+      const node = createNode(nodes, score, attributes, document)
       nodes[JSON.stringify(attributes) + score] = { node, score }
     }
 

--- a/packages/fela-dom/src/dom/connection/__tests__/createNode-test.js
+++ b/packages/fela-dom/src/dom/connection/__tests__/createNode-test.js
@@ -17,8 +17,13 @@ describe('Creating a style node', () => {
     const getHTML = (media, support, rendererId = '') => ({
       _media: media,
       _support: support,
-      html: createNode({}, 0, { type: RULE_TYPE, media, support }, document, rendererId)
-        .outerHTML,
+      html: createNode(
+        {},
+        0,
+        { type: RULE_TYPE, media, support },
+        document,
+        rendererId
+      ).outerHTML,
     })
 
     expect(getHTML()).toMatchSnapshot()

--- a/packages/fela-dom/src/dom/connection/__tests__/queryNode-test.js
+++ b/packages/fela-dom/src/dom/connection/__tests__/queryNode-test.js
@@ -29,5 +29,7 @@ it('should query by "data-fela-id"', () => {
     '<style data-fela-id="ID" data-fela-type="RULE" type="text/css">.a{color: red}</style>'
   document.head.innerHTML = nodeValid
 
-  expect(queryNode({ type: RULE_TYPE }, document, 'ID').outerHTML).toBe(nodeValid)
+  expect(queryNode({ type: RULE_TYPE }, document, 'ID').outerHTML).toBe(
+    nodeValid
+  )
 })

--- a/packages/fela-dom/src/dom/connection/__tests__/queryNode-test.js
+++ b/packages/fela-dom/src/dom/connection/__tests__/queryNode-test.js
@@ -10,7 +10,7 @@ it('should not query nodes with media attributes if media is not defined', () =>
 
   document.head.innerHTML = nodeInvalid + nodeValid
 
-  expect(queryNode({ type: RULE_TYPE }).outerHTML).toBe(nodeValid)
+  expect(queryNode({ type: RULE_TYPE }, document).outerHTML).toBe(nodeValid)
 })
 
 it('should not query nodes with support attributes if support is not defined', () => {
@@ -21,7 +21,7 @@ it('should not query nodes with support attributes if support is not defined', (
 
   document.head.innerHTML = nodeInvalid + nodeValid
 
-  expect(queryNode({ type: RULE_TYPE }).outerHTML).toBe(nodeValid)
+  expect(queryNode({ type: RULE_TYPE }, document).outerHTML).toBe(nodeValid)
 })
 
 it('should query by "data-fela-id"', () => {
@@ -29,5 +29,5 @@ it('should query by "data-fela-id"', () => {
     '<style data-fela-id="ID" data-fela-type="RULE" type="text/css">.a{color: red}</style>'
   document.head.innerHTML = nodeValid
 
-  expect(queryNode({ type: RULE_TYPE }, 'ID').outerHTML).toBe(nodeValid)
+  expect(queryNode({ type: RULE_TYPE }, document, 'ID').outerHTML).toBe(nodeValid)
 })

--- a/packages/fela-dom/src/dom/connection/createNode.js
+++ b/packages/fela-dom/src/dom/connection/createNode.js
@@ -7,11 +7,12 @@ export default function createNode(
   nodes: Object,
   score: number,
   { type, media, support }: NodeAttributes,
+  targetDocument: Document,
   id?: string = ''
 ): Object {
-  const head = document.head || {}
+  const head = targetDocument.head || {}
 
-  const node = document.createElement('style')
+  const node = targetDocument.createElement('style')
   node.setAttribute('data-fela-id', id)
   node.setAttribute('data-fela-type', type)
   node.type = 'text/css'

--- a/packages/fela-dom/src/dom/connection/getNodeFromCache.js
+++ b/packages/fela-dom/src/dom/connection/getNodeFromCache.js
@@ -23,8 +23,14 @@ export default function getNodeFromCache(
   if (!renderer.nodes[reference]) {
     const score = calculateNodeScore(attributes, renderer.mediaQueryOrder)
     const node =
-      queryNode(attributes, renderer.rendererId) ||
-      createNode(renderer.nodes, score, attributes, renderer.rendererId)
+      queryNode(attributes, renderer.targetDocument, renderer.rendererId) ||
+      createNode(
+        renderer.nodes,
+        score,
+        attributes,
+        renderer.targetDocument,
+        renderer.rendererId
+      )
 
     renderer.nodes[reference] = {
       node,

--- a/packages/fela-dom/src/dom/connection/queryNode.js
+++ b/packages/fela-dom/src/dom/connection/queryNode.js
@@ -3,6 +3,7 @@ import type { NodeAttributes } from '../../../../../flowtypes/DOMNode'
 
 export default function queryNode(
   { type, media, support }: NodeAttributes,
+  targetDocument: Document,
   id?: string = ''
 ): ?Object {
   const idQuery = `[data-fela-id="${id}"]`
@@ -11,7 +12,7 @@ export default function queryNode(
     ? '[data-fela-support="true"]'
     : ':not([data-fela-support="true"])'
 
-  return document.querySelector(
+  return targetDocument.querySelector(
     `[data-fela-type="${type}"]${idQuery}${supportQuery}${mediaQuery}`
   )
 }

--- a/packages/fela-dom/src/dom/rehydrate.js
+++ b/packages/fela-dom/src/dom/rehydrate.js
@@ -18,8 +18,9 @@ export default function rehydrate(renderer: DOMRenderer): void {
   render(renderer)
 
   const idQuery = `[data-fela-id="${renderer.rendererId}"]`
+  const nodes = renderer.targetDocument.querySelectorAll(`[data-fela-type]${idQuery}`)
 
-  arrayEach(document.querySelectorAll(`[data-fela-type]${idQuery}`), node => {
+  arrayEach(nodes, node => {
     const rehydrationAttribute =
       node.getAttribute('data-fela-rehydration') || -1
     const rehydrationIndex =

--- a/packages/fela-dom/src/dom/rehydrate.js
+++ b/packages/fela-dom/src/dom/rehydrate.js
@@ -18,7 +18,9 @@ export default function rehydrate(renderer: DOMRenderer): void {
   render(renderer)
 
   const idQuery = `[data-fela-id="${renderer.rendererId}"]`
-  const nodes = renderer.targetDocument.querySelectorAll(`[data-fela-type]${idQuery}`)
+  const nodes = renderer.targetDocument.querySelectorAll(
+    `[data-fela-type]${idQuery}`
+  )
 
   arrayEach(nodes, node => {
     const rehydrationAttribute =

--- a/packages/fela-integration/src/jest-react-fela_react-fela/__tests__/ThemeProviderFactory-test.js
+++ b/packages/fela-integration/src/jest-react-fela_react-fela/__tests__/ThemeProviderFactory-test.js
@@ -1,6 +1,5 @@
 import 'raf/polyfill'
-import React, { Component } from 'react'
-import PropTypes from 'prop-types'
+import React from 'react'
 
 import { createSnapshot } from 'jest-react-fela'
 import { ThemeProvider, FelaTheme } from 'react-fela'

--- a/packages/fela-integration/src/jest-react-fela_react-fela/__tests__/createComponent-test.js
+++ b/packages/fela-integration/src/jest-react-fela_react-fela/__tests__/createComponent-test.js
@@ -1,7 +1,6 @@
 import 'raf/polyfill'
 import React from 'react'
 
-import { createRenderer } from 'fela'
 import { createSnapshot } from 'jest-react-fela'
 import { createComponent } from 'react-fela'
 

--- a/packages/fela-integration/src/jest-react-fela_react-fela/__tests__/createComponent_fela-monolithic-test.js
+++ b/packages/fela-integration/src/jest-react-fela_react-fela/__tests__/createComponent_fela-monolithic-test.js
@@ -4,7 +4,7 @@ import React from 'react'
 import { createRenderer } from 'fela'
 import { createSnapshot } from 'jest-react-fela'
 import monolithic from 'fela-monolithic'
-import { createComponent, createComponentWithProxy } from 'react-fela'
+import { createComponent } from 'react-fela'
 
 describe('Creating Components from Fela rules using fela-monolithic', () => {
   it('should use a dev-friendly className', () => {

--- a/packages/fela-tools/src/renderToString.js
+++ b/packages/fela-tools/src/renderToString.js
@@ -1,13 +1,6 @@
 /* @flow */
 import arrayReduce from 'fast-loops/lib/arrayReduce'
-import {
-  clusterCache,
-  cssifySupportRules,
-  RULE_TYPE,
-  KEYFRAME_TYPE,
-  STATIC_TYPE,
-  FONT_TYPE,
-} from 'fela-utils'
+import { clusterCache, cssifySupportRules } from 'fela-utils'
 
 import cssifyMediaQueryRules from './cssifyMediaQueryRules'
 

--- a/packages/fela/src/createRenderer.js
+++ b/packages/fela/src/createRenderer.js
@@ -57,6 +57,7 @@ export default function createRenderer(
 
     rendererId: validateSelectorPrefix(config.rendererId),
     selectorPrefix: validateSelectorPrefix(config.selectorPrefix),
+    targetDocument: config.targetDocument || document,
     filterClassName: config.filterClassName || isSafeClassName,
     devMode: config.devMode || false,
 

--- a/packages/react-fela/src/ThemeProvider.js
+++ b/packages/react-fela/src/ThemeProvider.js
@@ -1,7 +1,6 @@
 /* @flow */
 import { createElement, Children } from 'react'
 import { ThemeProviderFactory } from 'fela-bindings'
-import PropTypes from 'prop-types'
 
 import { ThemeContext } from './context'
 


### PR DESCRIPTION
Fixes #693.

## Description
This PR adds an `targetDocument` option to `createRenderer()` that allows to render styles properly to child windows: https://github.com/stardust-ui/react/issues/1178

## Packages

- `fela`
- `fela-dom`

## Versioning
Minor

## Checklist

#### Quality Assurance

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

