### PR TITLE
Adding fela-plugin-expand-shorthand

### DIFF
--- a/docs/introduction/Ecosystem.md
+++ b/docs/introduction/Ecosystem.md
@@ -30,6 +30,7 @@ Many plugins and enhancers are already included in the [main repository](https:/
 * [fela-plugin-bidi](https://github.com/rofrischmann/fela/tree/master/packages/fela-plugin-bidi) - Enable direction-independent style authoring
 * [fela-plugin-custom-property](https://github.com/rofrischmann/fela/tree/master/packages/fela-plugin-custom-property) - Resolves custom properties
 * [fela-plugin-embedded](https://github.com/rofrischmann/fela/tree/master/packages/fela-plugin-embedded) - Automatically resolves embedded font faces and keyframes within rules
+* [fela-plugin-expand-shorthand](https://github.com/rofrischmann/fela/tree/master/packages/fela-plugin-expand-shorthand) - Expand shorthand properties and optionally merge them
 * [fela-plugin-extend](https://github.com/rofrischmann/fela/tree/master/packages/fela-plugin-extend) - Extend style objects based on conditions
 * [fela-plugin-fallback-value](https://github.com/rofrischmann/fela/tree/master/packages/fela-plugin-fallback-value) - Resolves arrays of fallback values
 * [fela-plugin-friendly-pseudo-class](https://github.com/rofrischmann/fela/tree/master/packages/fela-plugin-friendly-pseudo-class) - Transforms javascript-friendly pseudo class into valid syntax
@@ -55,6 +56,7 @@ Many plugins and enhancers are already included in the [main repository](https:/
 * [fela-monolithic](https://github.com/rofrischmann/fela/tree/master/packages/fela-monolithic) - Render component-based (monolithic) CSS classes (rather than atomic)
 * [fela-identifier](https://github.com/rofrischmann/fela/tree/master/packages/fela-identifier) - Allows to create rules for which the renderer will generate unique class names (useful for nested selectors)
 * [fela-perf*](https://github.com/rofrischmann/fela/tree/master/packages/fela-perf) - Logs performance information (time elapsed while rendering)
+* [fela-sort-classnames](https://github.com/rofrischmann/fela/tree/master/packages/fela-sort-classnames) - Deterministically sort rendered class names to prevent browser incompatibilities
 * [fela-statistics*](https://github.com/rofrischmann/fela/tree/master/packages/fela-statistics) - Collects different metrics to analyze your styles
 
 ### Components

--- a/packages/fela-plugin-expand-shorthand/LICENSE
+++ b/packages/fela-plugin-expand-shorthand/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 Robin Frischmann
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/fela-plugin-expand-shorthand/README.md
+++ b/packages/fela-plugin-expand-shorthand/README.md
@@ -1,0 +1,62 @@
+# fela-plugin-expand-shorthand
+
+<img alt="npm version" src="https://badge.fury.io/js/fela-plugin-expand-shorthand.svg"> <img alt="npm downloads" src="https://img.shields.io/npm/dm/fela-plugin-expand-shorthand.svg"> <a href="https://bundlephobia.com/result?p=fela-plugin-expand-shorthand@latest"><img alt="Bundlephobia" src="https://img.shields.io/bundlephobia/minzip/fela-plugin-expand-shorthand.svg"></a>
+
+Expands shorthand properties in style objects so that only longhand properties are used.
+
+It uses [inline-style-expand-shorthand](https://github.com/rofrischmann/inline-style-expand-shorthand) under the hood. Check the repo if you're interested in which properties are supported.
+
+It comes in two different modes: One that simply expands the shorthands and one that merges the resulting longhands with existing longhands in the style object depending on the specificity of that property.
+
+## Installation
+```sh
+yarn add fela-plugin-expand-shorthand
+```
+You may alternatively use `npm i --save fela-plugin-expand-shorthand`.
+
+## Usage
+Make sure to read the documentation on [how to use plugins](http://fela.js.org/docs/advanced/Plugins.html).
+
+```javascript
+import { createRenderer } from 'fela'
+import expandShorthand from 'fela-plugin-expand-shorthand'
+
+const renderer = createRenderer({
+  plugins: [ expandShorthand() ]
+})
+```
+
+### Configuration
+In order to get enable auto-merging of longhands, one needs to pass a configuration flag.
+
+```javascript
+import { createRenderer } from 'fela'
+import expandShorthand from 'fela-plugin-expand-shorthand'
+
+const renderer = createRenderer({
+  plugins: [ expandShorthand(true) ]
+})
+```
+
+## Example
+
+#### Input
+```javascript
+{
+  padding: '15px 20px 5px'
+}
+```
+#### Output
+```javascript
+{
+  paddingTop: '15px',
+  paddingRight: '20px',
+  paddingBottom: '15px',
+  paddingLeft: '5px'
+}
+```
+
+## License
+Fela is licensed under the [MIT License](http://opensource.org/licenses/MIT).<br>
+Documentation is licensed under [Creative Common License](http://creativecommons.org/licenses/by/4.0/).<br>
+Created with ♥ by [@rofrischmann](http://rofrischmann.de) and all the great contributors.

--- a/packages/fela-plugin-expand-shorthand/package.json
+++ b/packages/fela-plugin-expand-shorthand/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "fela-plugin-expand-shorthand",
+  "version": "10.4.1",
+  "description": "Fela plugin to expand shorthand properties in style objects",
+  "main": "lib/index.js",
+  "module": "es/index.js",
+  "jsnext:main": "es/index.js",
+  "sideEffects": false,
+  "files": [
+    "LICENSE",
+    "README.md",
+    "lib/**",
+    "es/**"
+  ],
+  "repository": "https://github.com/rofrischmann/fela/",
+  "keywords": [
+    "fela",
+    "fela-plugin",
+    "shorthands",
+    "css-shorthands",
+    "longhands"
+  ],
+  "author": "Robin Frischmann",
+  "license": "MIT",
+  "dependencies": {
+    "inline-style-expand-shorthand": "^1.1.1"
+  },
+  "gitHead": "4edeeffc5be2e05473a52c24523dbebcd9e0ef0d"
+}

--- a/packages/fela-plugin-expand-shorthand/src/__tests__/expandShorthand-test.js
+++ b/packages/fela-plugin-expand-shorthand/src/__tests__/expandShorthand-test.js
@@ -1,0 +1,31 @@
+import expandShorthand from '../index'
+
+describe('Expand Shorthand plugin', () => {
+  it('should expand shorthands in style objects', () => {
+    const style = {
+      paddingLeft: '10px',
+      padding: '15px',
+    }
+
+    expect(expandShorthand(false)(style)).toEqual({
+      paddingLeft: '15px',
+      paddingRight: '15px',
+      paddingTop: '15px',
+      paddingBottom: '15px',
+    })
+  })
+
+  it('should expand and merge shorthands in style objects', () => {
+    const style = {
+      paddingLeft: '10px',
+      padding: '15px',
+    }
+
+    expect(expandShorthand(true)(style)).toEqual({
+      paddingLeft: '10px',
+      paddingRight: '15px',
+      paddingTop: '15px',
+      paddingBottom: '15px',
+    })
+  })
+})

--- a/packages/fela-plugin-expand-shorthand/src/index.js
+++ b/packages/fela-plugin-expand-shorthand/src/index.js
@@ -1,0 +1,14 @@
+/* @flow */
+import { expandWithMerge, expand } from 'inline-style-expand-shorthand'
+
+function expandShorthand(style: Object, shouldMerge: boolean): Object {
+  if (shouldMerge) {
+    return expandWithMerge(style)
+  }
+
+  return expand(style)
+}
+
+export default function resolveShorthands(merge: boolean = false) {
+  return (style: Object) => expandShorthand(style, merge)
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8866,6 +8866,11 @@ init-package-json@~1.9.4:
     validate-npm-package-license "^3.0.1"
     validate-npm-package-name "^3.0.0"
 
+inline-style-expand-shorthand@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/inline-style-expand-shorthand/-/inline-style-expand-shorthand-1.1.1.tgz#0b0dbd34cfe6e62a2d21c077b2c8cdbe367224de"
+  integrity sha512-O8rMrfUxzQ2SGqkGvb+3JI611JXy8lgClq6RulN+K9R4qRPDiZ+ajeqYLBg3bmxtAoM4SX4o6zU9PLzBJpsiDQ==
+
 inline-style-prefixer@^2.0.0, inline-style-prefixer@^2.0.1, inline-style-prefixer@^2.0.4:
   version "2.0.5"
   resolved "http://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-2.0.5.tgz#c153c7e88fd84fef5c602e95a8168b2770671fe7"


### PR DESCRIPTION
<!------------------------------------------
  Thanks for contributing!
  Please read the guidelines at the bottom.
------------------------------------------->

## Description
This plugin expands (and merge) shorthand properties and longhand properties in style objects.

## Example
If required, add a code example or a link to a working example (repository).

#### Input
```javascript
// before
{
  padding: '15px 20px 5px'
}

// after
{
  paddingTop: '15px',
  paddingRight: '20px',
  paddingBottom: '15px',
  paddingLeft: '5px'
}
```

## Packages
- fela-plugin-expand-shorthand

## Versioning
Minor

## Checklist

#### Quality Assurance
> You can also run `yarn run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`yarn run format`)
- [x] The code has no linting errors (`yarn run lint`)
- [x] All tests are passing (`yarn run test`) 
- [x] There are no flow-type errors (`yarn run flow`)

#### Changes
If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
- [x] My changes have proper flow-types

