### PR TITLE
fix: ignore relative selector lists when resolving multiple selectors

### DIFF
--- a/packages/fela-plugin-multiple-selectors/src/__tests__/multipleSelectors-test.js
+++ b/packages/fela-plugin-multiple-selectors/src/__tests__/multipleSelectors-test.js
@@ -99,4 +99,20 @@ describe('multiple-selectors plugin', () => {
       },
     })
   })
+
+  it('should not resolve relative selector lists', () => {
+    const style = {
+      ':not(:hover, :focus)': {
+        color: 'blue',
+        fontSize: 12,
+      },
+    }
+
+    expect(multipleSelectors()(style)).toEqual({
+      ':not(:hover, :focus)': {
+        color: 'blue',
+        fontSize: 12,
+      },
+    })
+  })
 })

--- a/packages/fela-plugin-multiple-selectors/src/index.js
+++ b/packages/fela-plugin-multiple-selectors/src/index.js
@@ -6,7 +6,9 @@ function multipleSelectorsPlugin(style) {
     if (isPlainObject(value)) {
       const resolvedValue = multipleSelectorsPlugin(value)
 
-      const selectors = property.split(',')
+      // split on commas, but not within a relative selector list
+      //   e.g. ":hover, :focus", but not ":where(:hover, :focus)"
+      const selectors = property.split(/(?<!\([^)]*),(?![^(]*\))/)
 
       if (selectors.length > 1) {
         arrayEach(selectors, (selector) => {


### PR DESCRIPTION
## Description

`fela-multiple-selectors-plugin` currently naively splits selectors on `,`, but this doesn't account for relative selector lists that may be within a pseudo-class. This results in invalid selectors being resolved.

This PR fixes that issue by making use of lookahead and lookbehind assertions when splitting to avoid matching within pseudo-class selector lists.

## Example

```css
:not(:hover, :focus) {}
```
currently resolves to `:not(:hover` and `:focus)`, both of which are invalid.

With this PR, the selector remains whole as `:not(:hover, :focus)`.

## Packages

List all packages that have been changed.

- `fela-plugin-multiple-selectors`

## Versioning

Patch

## Checklist

#### Quality Assurance

> You can also run `pnpm run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`pnpm run format`)
- [x] The code has no linting errors (`pnpm run lint`)
- [x] All tests are passing (`pnpm run test`)

#### Changes

If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [x] Documentation has been added/updated
