### PR TITLE
feat: Allow ampersand suffixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,5 +77,6 @@
         ]
       }
     }
-  }
+  },
+  "packageManager": "pnpm@8.7.6+sha1.a428b12202bc4f23b17e6dffe730734dae5728e2"
 }

--- a/packages/fela-integration/src/fela_fela-tools/__tests__/__snapshots__/integration-test.js.snap
+++ b/packages/fela-integration/src/fela_fela-tools/__tests__/__snapshots__/integration-test.js.snap
@@ -16,6 +16,8 @@ exports[`Fela with Fela Tools integration Rendering rules should remove undefine
 
 exports[`Fela with Fela Tools integration Rendering rules should render any nested selector with the &-prefix 1`] = `".a{color:red}.b~#foo{color:blue}.c .bar{color:green}"`;
 
+exports[`Fela with Fela Tools integration Rendering rules should render any nested selector with the &-suffix 1`] = `".a{color:red}.bar:hover .b{color:green}"`;
+
 exports[`Fela with Fela Tools integration Rendering rules should render attribute selectors 1`] = `".a{color:red}.b[bool=true]{color:blue}"`;
 
 exports[`Fela with Fela Tools integration Rendering rules should render attribute selectors and add specificity prefix 1`] = `".parent .a{color:red}.parent .b[bool=true]{color:blue}"`;

--- a/packages/fela-integration/src/fela_fela-tools/__tests__/integration-test.js
+++ b/packages/fela-integration/src/fela_fela-tools/__tests__/integration-test.js
@@ -142,7 +142,6 @@ describe('Fela with Fela Tools integration', () => {
       expect(renderToString(renderer)).toMatchSnapshot()
     })
 
-
     it('should render media queries', () => {
       const rule = () => ({
         color: 'red',

--- a/packages/fela-integration/src/fela_fela-tools/__tests__/integration-test.js
+++ b/packages/fela-integration/src/fela_fela-tools/__tests__/integration-test.js
@@ -128,6 +128,21 @@ describe('Fela with Fela Tools integration', () => {
       expect(renderToString(renderer)).toMatchSnapshot()
     })
 
+    it('should render any nested selector with the &-suffix', () => {
+      const rule = () => ({
+        color: 'red',
+        '.bar:hover &': {
+          color: 'green',
+        },
+      })
+      const renderer = createRenderer()
+
+      renderer.renderRule(rule)
+
+      expect(renderToString(renderer)).toMatchSnapshot()
+    })
+
+
     it('should render media queries', () => {
       const rule = () => ({
         color: 'red',

--- a/packages/fela-utils/src/__tests__/isNestedSelector-test.js
+++ b/packages/fela-utils/src/__tests__/isNestedSelector-test.js
@@ -7,11 +7,13 @@ describe('Validating nested selectors', () => {
     expect(isNestedSelector('> div')).toEqual(true)
     expect(isNestedSelector('& .foo')).toEqual(true)
     expect(isNestedSelector('& ~ #id')).toEqual(true)
+    expect(isNestedSelector('.foo &')).toEqual(true)
   })
 
   it('should return false', () => {
     expect(isNestedSelector('.foo')).toEqual(false)
     expect(isNestedSelector(' .foo')).toEqual(false)
     expect(isNestedSelector('~ #id')).toEqual(false)
+    expect(isNestedSelector('#id & .foo')).toEqual(false)
   })
 })

--- a/packages/fela-utils/src/generateCSSSelector.js
+++ b/packages/fela-utils/src/generateCSSSelector.js
@@ -2,12 +2,12 @@ export default function generateCSSSelector(
   className,
   pseudo = '',
   specificityPrefix = '',
-  propertyPriority = 1,
-  psuedoPrefix = false
+  propertyPriority = 1
 ) {
   const classNameSelector = `.${className}`.repeat(propertyPriority)
-  if (psuedoPrefix) {
-    return `${specificityPrefix}${pseudo}${classNameSelector}`
+  if (pseudo.includes('&')) {
+    pseudo = pseudo.replace('&', classNameSelector)
+    return `${specificityPrefix}${pseudo}`
   }
   return `${specificityPrefix}${classNameSelector}${pseudo}`
 }

--- a/packages/fela-utils/src/generateCSSSelector.js
+++ b/packages/fela-utils/src/generateCSSSelector.js
@@ -2,9 +2,12 @@ export default function generateCSSSelector(
   className,
   pseudo = '',
   specificityPrefix = '',
-  propertyPriority = 1
+  propertyPriority = 1,
+  psuedoPrefix = false
 ) {
   const classNameSelector = `.${className}`.repeat(propertyPriority)
-
+  if (psuedoPrefix) {
+    return `${specificityPrefix}${pseudo}${classNameSelector}`
+  }
   return `${specificityPrefix}${classNameSelector}${pseudo}`
 }

--- a/packages/fela-utils/src/generateCSSSelector.js
+++ b/packages/fela-utils/src/generateCSSSelector.js
@@ -2,12 +2,12 @@ export default function generateCSSSelector(
   className,
   pseudo = '',
   specificityPrefix = '',
-  propertyPriority = 1
+  propertyPriority = 1,
+  psuedoPrefix = false
 ) {
   const classNameSelector = `.${className}`.repeat(propertyPriority)
-  if (pseudo.includes('&')) {
-    pseudo = pseudo.replace('&', classNameSelector)
-    return `${specificityPrefix}${pseudo}`
+  if (psuedoPrefix) {
+    return `${specificityPrefix}${pseudo}${classNameSelector}`
   }
   return `${specificityPrefix}${classNameSelector}${pseudo}`
 }

--- a/packages/fela-utils/src/isNestedSelector.js
+++ b/packages/fela-utils/src/isNestedSelector.js
@@ -1,5 +1,5 @@
-const regex = /^(:|\[|>|&)/
+const prefix = /^(:|\[|>|&)/
 
 export default function isNestedSelector(property) {
-  return regex.test(property)
+  return prefix.test(property) || property.endsWith('&')
 }

--- a/packages/fela-utils/src/normalizeNestedProperty.js
+++ b/packages/fela-utils/src/normalizeNestedProperty.js
@@ -2,6 +2,9 @@ export default function normalizeNestedProperty(nestedProperty) {
   if (nestedProperty.charAt(0) === '&') {
     return nestedProperty.substr(1)
   }
+  if (nestedProperty.endsWith('&')) {
+    return nestedProperty.substr(0, nestedProperty.length - 1)
+  }
 
   return nestedProperty
 }

--- a/packages/fela/src/createRenderer.js
+++ b/packages/fela/src/createRenderer.js
@@ -10,6 +10,7 @@ import {
   isNestedSelector,
   isUndefinedValue,
   isSupport,
+  normalizeNestedProperty,
   processStyleWithPlugins,
   STATIC_TYPE,
   RULE_TYPE,
@@ -199,7 +200,13 @@ export default function createRenderer(config = {}) {
       )
     },
 
-    _renderStyleToClassNames(style, pseudo = '', media = '', support = '') {
+    _renderStyleToClassNames(
+      style,
+      pseudo = '',
+      media = '',
+      support = '',
+      psuedoPrefix = false
+    ) {
       let classNames = ''
 
       const applyPlugin = (processed, plugin) => plugin(processed, renderer)
@@ -211,9 +218,10 @@ export default function createRenderer(config = {}) {
           if (isNestedSelector(property)) {
             classNames += renderer._renderStyleToClassNames(
               value,
-              pseudo + property,
+              pseudo + normalizeNestedProperty(property),
               media,
-              support
+              support,
+              property.endsWith('&')
             )
           } else if (isMediaQuery(property)) {
             const combinedMediaQuery = generateCombinedMediaQuery(
@@ -299,7 +307,8 @@ Check http://fela.js.org/docs/basics/Rules.html#styleobject for more information
               value,
               pseudo,
               media,
-              support
+              support,
+              psuedoPrefix
             )
           }
 
@@ -315,7 +324,15 @@ Check http://fela.js.org/docs/basics/Rules.html#styleobject for more information
       return classNames
     },
 
-    _renderStyleToCache(reference, property, value, pseudo, media, support) {
+    _renderStyleToCache(
+      reference,
+      property,
+      value,
+      pseudo,
+      media,
+      support,
+      psuedoPrefix
+    ) {
       // we remove undefined values to enable
       // usage of optional props without side-effects
       if (isUndefinedValue(value)) {
@@ -335,7 +352,8 @@ Check http://fela.js.org/docs/basics/Rules.html#styleobject for more information
         className,
         pseudo,
         config.specificityPrefix,
-        renderer.propertyPriority[property]
+        renderer.propertyPriority[property],
+        psuedoPrefix
       )
 
       const change = {

--- a/packages/fela/src/createRenderer.js
+++ b/packages/fela/src/createRenderer.js
@@ -200,7 +200,13 @@ export default function createRenderer(config = {}) {
       )
     },
 
-    _renderStyleToClassNames(style, pseudo = '', media = '', support = '') {
+    _renderStyleToClassNames(
+      style,
+      pseudo = '',
+      media = '',
+      support = '',
+      psuedoPrefix = false
+    ) {
       let classNames = ''
 
       const applyPlugin = (processed, plugin) => plugin(processed, renderer)
@@ -214,7 +220,8 @@ export default function createRenderer(config = {}) {
               value,
               pseudo + normalizeNestedProperty(property),
               media,
-              support
+              support,
+              property.endsWith('&')
             )
           } else if (isMediaQuery(property)) {
             const combinedMediaQuery = generateCombinedMediaQuery(
@@ -300,7 +307,8 @@ Check http://fela.js.org/docs/basics/Rules.html#styleobject for more information
               value,
               pseudo,
               media,
-              support
+              support,
+              psuedoPrefix
             )
           }
 
@@ -316,7 +324,15 @@ Check http://fela.js.org/docs/basics/Rules.html#styleobject for more information
       return classNames
     },
 
-    _renderStyleToCache(reference, property, value, pseudo, media, support) {
+    _renderStyleToCache(
+      reference,
+      property,
+      value,
+      pseudo,
+      media,
+      support,
+      psuedoPrefix
+    ) {
       // we remove undefined values to enable
       // usage of optional props without side-effects
       if (isUndefinedValue(value)) {
@@ -336,7 +352,8 @@ Check http://fela.js.org/docs/basics/Rules.html#styleobject for more information
         className,
         pseudo,
         config.specificityPrefix,
-        renderer.propertyPriority[property]
+        renderer.propertyPriority[property],
+        psuedoPrefix
       )
 
       const change = {

--- a/packages/fela/src/createRenderer.js
+++ b/packages/fela/src/createRenderer.js
@@ -10,7 +10,6 @@ import {
   isNestedSelector,
   isUndefinedValue,
   isSupport,
-  normalizeNestedProperty,
   processStyleWithPlugins,
   STATIC_TYPE,
   RULE_TYPE,
@@ -200,13 +199,7 @@ export default function createRenderer(config = {}) {
       )
     },
 
-    _renderStyleToClassNames(
-      style,
-      pseudo = '',
-      media = '',
-      support = '',
-      psuedoPrefix = false
-    ) {
+    _renderStyleToClassNames(style, pseudo = '', media = '', support = '') {
       let classNames = ''
 
       const applyPlugin = (processed, plugin) => plugin(processed, renderer)
@@ -218,10 +211,9 @@ export default function createRenderer(config = {}) {
           if (isNestedSelector(property)) {
             classNames += renderer._renderStyleToClassNames(
               value,
-              pseudo + normalizeNestedProperty(property),
+              pseudo + property,
               media,
-              support,
-              property.endsWith('&')
+              support
             )
           } else if (isMediaQuery(property)) {
             const combinedMediaQuery = generateCombinedMediaQuery(
@@ -307,8 +299,7 @@ Check http://fela.js.org/docs/basics/Rules.html#styleobject for more information
               value,
               pseudo,
               media,
-              support,
-              psuedoPrefix
+              support
             )
           }
 
@@ -324,15 +315,7 @@ Check http://fela.js.org/docs/basics/Rules.html#styleobject for more information
       return classNames
     },
 
-    _renderStyleToCache(
-      reference,
-      property,
-      value,
-      pseudo,
-      media,
-      support,
-      psuedoPrefix
-    ) {
+    _renderStyleToCache(reference, property, value, pseudo, media, support) {
       // we remove undefined values to enable
       // usage of optional props without side-effects
       if (isUndefinedValue(value)) {
@@ -352,8 +335,7 @@ Check http://fela.js.org/docs/basics/Rules.html#styleobject for more information
         className,
         pseudo,
         config.specificityPrefix,
-        renderer.propertyPriority[property],
-        psuedoPrefix
+        renderer.propertyPriority[property]
       )
 
       const change = {


### PR DESCRIPTION
## Description

Allows nested rules like:

```js
".Group:hover &": { color: "white" },
```

Where the `&` comes at the end.

Output:

```css
.Group:hover .a { color: "white" }
```

This effectively fixes #702 , and mimics the Tailwinds capability of styling a child based on "some parent" being hovered. 

I definitely understand the "nested selectors are terrible", and we have ~very few in our codebase :sweat_smile: (that currently uses Emotion), but this "change my style based on my parent", particularly with a CSS-driven `:hover` (instead of tracking parent hover state in JS), seems like a valid usage. 

## Packages

* fela
* fela-utils

## Versioning

Minor

## Checklist

#### Quality Assurance

> You can also run `pnpm run check` to run all 4 commands at once.

- [x] The code was formatted using Prettier (`pnpm run format`)
- [x] The code has no linting errors (`pnpm run lint`)
- [x] All tests are passing (`pnpm run test`)

#### Changes

If one of the following checks doesn't make sense due to the type of PR, just check them.

- [x] Tests have been added/updated
- [ ] Documentation has been added/updated
